### PR TITLE
Include LICENSE file on PyPI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,44 @@
+# To use:
+#
+#     pre-commit run -a
+#
+# Or:
+#
+#     pre-commit install  # (runs every time you commit in git)
+#
+# To update this file:
+#
+#     pre-commit autoupdate
+#
+# See https://github.com/pre-commit/pre-commit
+
+repos:
+# Standard hooks
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.0.1
+  hooks:
+  - id: check-case-conflict
+  - id: check-docstring-first
+  - id: check-executables-have-shebangs
+  - id: check-merge-conflict
+  - id: check-symlinks
+  - id: check-yaml
+  - id: debug-statements
+  - id: end-of-file-fixer
+  - id: mixed-line-ending
+  - id: sort-simple-yaml
+  - id: file-contents-sorter
+  - id: trailing-whitespace
+    exclude: ^doc/_static/.*.svg
+
+# Python linter (Flake8)
+- repo: https://github.com/PyCQA/flake8
+  rev: 3.9.2
+  hooks:
+  - id: flake8
+
+# Python formatting
+- repo: https://github.com/psf/black
+  rev: 21.6b0
+  hooks:
+  - id: black

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE pyproject.toml README.md setup.py setup.cfg

--- a/numba_stats/__init__.py
+++ b/numba_stats/__init__.py
@@ -22,6 +22,7 @@ from .stats import (  # noqa
 
 from argparse import Namespace
 
+# TODO this does not work in numba
 uniform = Namespace(pdf=uniform_pdf, cdf=uniform_cdf, ppf=uniform_ppf)
 norm = Namespace(pdf=norm_pdf, cdf=norm_cdf, ppf=norm_ppf)
 poisson = Namespace(pmf=poisson_pmf, cdf=poisson_cdf)

--- a/numba_stats/__init__.py
+++ b/numba_stats/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.6.0"  # noqa
+__version__ = "0.6.1"  # noqa
 
 from .stats import (  # noqa
     uniform_pdf,


### PR DESCRIPTION
The conda-forge release failed as the license file wasn't included in the sdist on PyPI for the latest release: https://github.com/conda-forge/numba-stats-feedstock/pull/7