### PR TITLE
Added a continuous version of the poisson distribution

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,44 @@
+# To use:
+#
+#     pre-commit run -a
+#
+# Or:
+#
+#     pre-commit install  # (runs every time you commit in git)
+#
+# To update this file:
+#
+#     pre-commit autoupdate
+#
+# See https://github.com/pre-commit/pre-commit
+
+repos:
+# Standard hooks
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.0.1
+  hooks:
+  - id: check-case-conflict
+  - id: check-docstring-first
+  - id: check-executables-have-shebangs
+  - id: check-merge-conflict
+  - id: check-symlinks
+  - id: check-yaml
+  - id: debug-statements
+  - id: end-of-file-fixer
+  - id: mixed-line-ending
+  - id: sort-simple-yaml
+  - id: file-contents-sorter
+  - id: trailing-whitespace
+    exclude: ^doc/_static/.*.svg
+
+# Python linter (Flake8)
+- repo: https://github.com/PyCQA/flake8
+  rev: 3.9.2
+  hooks:
+  - id: flake8
+
+# Python formatting
+- repo: https://github.com/psf/black
+  rev: 21.6b0
+  hooks:
+  - id: black

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE pyproject.toml README.md setup.py setup.cfg

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-poetry run pytest --cov=numba_stats --cov-report=html
+pytest --cov=numba_stats --cov-report=html

--- a/numba_stats/__init__.py
+++ b/numba_stats/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.6.0"  # noqa
+__version__ = "0.6.1"  # noqa
 
 from .stats import (  # noqa
     uniform_pdf,
@@ -9,6 +9,8 @@ from .stats import (  # noqa
     norm_ppf,
     poisson_pmf,
     poisson_cdf,
+    cpoisson_pmf,
+    cpoisson_cdf,
     expon_pdf,
     expon_cdf,
     expon_ppf,
@@ -25,6 +27,7 @@ from argparse import Namespace
 uniform = Namespace(pdf=uniform_pdf, cdf=uniform_cdf, ppf=uniform_ppf)
 norm = Namespace(pdf=norm_pdf, cdf=norm_cdf, ppf=norm_ppf)
 poisson = Namespace(pmf=poisson_pmf, cdf=poisson_cdf)
+cpoisson = Namespace(pmf=cpoisson_pmf, cdf=cpoisson_cdf)
 expon = Namespace(pdf=expon_pdf, cdf=expon_cdf, ppf=expon_ppf)
 t = Namespace(pdf=t_pdf, cdf=t_cdf, ppf=t_ppf)
 voigt = Namespace(pdf=voigt_pdf)

--- a/numba_stats/__init__.py
+++ b/numba_stats/__init__.py
@@ -24,6 +24,7 @@ from .stats import (  # noqa
 
 from argparse import Namespace
 
+# TODO this does not work in numba
 uniform = Namespace(pdf=uniform_pdf, cdf=uniform_cdf, ppf=uniform_ppf)
 norm = Namespace(pdf=norm_pdf, cdf=norm_cdf, ppf=norm_ppf)
 poisson = Namespace(pmf=poisson_pmf, cdf=poisson_cdf)

--- a/numba_stats/stats.py
+++ b/numba_stats/stats.py
@@ -79,6 +79,36 @@ def poisson_cdf(x, mu):
 
 
 _signatures = [
+    nb.float32(nb.float32, nb.float32),
+    nb.float64(nb.float64, nb.float64),
+]
+
+
+@nb.vectorize(_signatures)
+def cpoisson_pmf(k, mu):
+    """
+    Return probability mass for Poisson distribution (allow non-integer k)
+    """
+    logp = xlogy(k, mu) - gammaln(k + 1.0) - mu
+    return np.exp(logp)
+
+
+_signatures = [
+    nb.float32(nb.float32, nb.float32),
+    nb.float64(nb.float64, nb.float64),
+]
+
+
+@nb.vectorize(_signatures)
+def cpoisson_cdf(x, mu):
+    """
+    Evaluate cumulative distribution function of Poisson distribution.
+    """
+    k = np.floor(x)
+    return pdtr(k, mu)
+
+
+_signatures = [
     nb.float32(nb.float32, nb.float32, nb.float32),
     nb.float64(nb.float64, nb.float64, nb.float64),
 ]

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -43,6 +43,22 @@ def test_poisson_cdf():
     np.testing.assert_allclose(got, expected)
 
 
+def test_cpoisson_pmf():
+    m = np.linspace(0.1, 3, 20)[:, np.newaxis]
+    k = np.arange(10)
+    got = nbs.cpoisson_pmf(k, m)
+    expected = sc.poisson.pmf(k, m)
+    np.testing.assert_allclose(got, expected)
+
+
+def test_cpoisson_cdf():
+    m = np.linspace(0.1, 3, 20)[:, np.newaxis]
+    k = np.arange(10)
+    got = nbs.cpoisson_cdf(k, m)
+    expected = sc.poisson.cdf(k, m)
+    np.testing.assert_allclose(got, expected)
+
+
 def test_expon_pdf():
     x = np.linspace(1, 5, 20)
     got = nbs.expon_pdf(x, 1, 2)


### PR DESCRIPTION
In the definition of the `poisson.pmf` the `signatures` only allow for an integer observation to be made. This makes sense because the Poisson distribution is a discrete probability distribution.

However when performing maximum likelihood fits it can be useful to make use of the "Asimov" dataset (see https://arxiv.org/pdf/1007.1727.pdf). In this case the observation is set to the expectation value and therefore the observation may be a non-integer number. To quote from the bottom of page 10 of https://arxiv.org/pdf/1007.1727.pdf:

"The use of non-interger values for the data is not a problem as the factorial terms in the Poisson likelihood represent constants that cancel when forming the likelihood ratio, and thus can be dropped."

So for this case it is useful to be able to define the a Poisson PMF which allows for non-integer `k`. Because of the way `numba-stats` already implements the Poisson distribution (making use of the `Gamma` function for factorials), the implementation for floating values of `k` is identical.

There are two possible solutions for this:

1. The first is to simply change the allowed `signatures` for the poisson PMF to accept floats. This is probably the cleanest, however it may lead to the confusion of some users and may make it harder to identify potential bugs (it also gives the user more scope for misuse). This will also overwrite the current implementation so has not been adopted here. @HDembinski perhaps you could consider whether you prefer this?

2. The alternative is to simply define a new distribution (in this MR it is called `cpoisson` which is meant to stand for Continuous Poisson). This simply makes a new distribution which allows a float to be passed. Otherwise its implementations of the `pmf` and `cdf` functions are identical to that of the `poisson` distribution. This is what has been done in this MR.

See the plot below which shows a comparison of the `poisson.pmf` (only valid for integer values of `k`) and the `cpoisson.pmf` which allows for continuous values.

![plot](https://user-images.githubusercontent.com/1140576/126308446-df760880-aefe-4320-8c67-24fd91b462be.png)

