### PR TITLE
removal of false implementation of cpoisson.pdf

### DIFF
--- a/src/numba_stats/_special.py
+++ b/src/numba_stats/_special.py
@@ -30,7 +30,6 @@ erfinv = get("erfinv", float64(float64))
 
 # binary functions (double)
 gammaincc = get("gammaincc", float64(float64, float64))
-pdtr = get("pdtr", float64(float64, float64))
 stdtr = get("stdtr", float64(float64, float64))
 stdtrit = get("stdtrit", float64(float64, float64))
 

--- a/src/numba_stats/cpoisson.py
+++ b/src/numba_stats/cpoisson.py
@@ -1,7 +1,6 @@
 import numba as nb
-import numpy as np
-from ._special import pdtr
-from math import lgamma
+from ._special import gammaincc
+
 
 _signatures = [
     nb.float32(nb.float32, nb.float32),
@@ -10,17 +9,19 @@ _signatures = [
 
 
 @nb.vectorize(_signatures)
-def pdf(x, mu):
-    """
-    Return probability density for continuous Poisson distribution (allow non-integer k).
-    """
-    logp = x * np.log(mu) - lgamma(x + 1.0) - mu
-    return np.exp(logp)
-
-
-@nb.vectorize(_signatures)
 def cdf(x, mu):
     """
     Evaluate cumulative distribution function of continuous Poisson distribution.
     """
-    return pdtr(x, mu)
+    return gammaincc(x + 1, mu)
+
+
+# The pdf, d cdf(x, mu)/ dx, cannot be expressed in tabulated functions:
+#
+# d G(x, mu)/d x = ln(mu) G(x, mu) + mu T(3, x, mu)
+#
+# where G(x, mu) is the upper incomplete gamma function and T(m, s, x) is a special case
+# of the Meijer G-function,
+# see https://en.wikipedia.org/wiki/Incomplete_gamma_function#Derivatives
+#
+# There is a Meijer G-function implemented in mpmath, but I don't know how to use it.

--- a/src/numba_stats/poisson.py
+++ b/src/numba_stats/poisson.py
@@ -1,6 +1,6 @@
 import numba as nb
 import numpy as np
-from ._special import pdtr
+from ._special import gammaincc
 from math import lgamma
 
 _signatures = [
@@ -23,4 +23,4 @@ def cdf(k, mu):
     """
     Evaluate cumulative distribution function of Poisson distribution.
     """
-    return pdtr(k, mu)
+    return gammaincc(k + 1, mu)

--- a/src/numba_stats/stats.py
+++ b/src/numba_stats/stats.py
@@ -15,7 +15,7 @@ norm.pdf(1, 2, 3)
 
 from .norm import pdf as norm_pdf, cdf as norm_cdf, ppf as norm_ppf  # noqa
 from .poisson import pmf as poisson_pmf, cdf as poisson_cdf  # noqa
-from .cpoisson import pdf as cpoisson_pdf, cdf as cpoisson_cdf  # noqa
+from .cpoisson import cdf as cpoisson_cdf  # noqa
 from .expon import pdf as expon_pdf, cdf as expon_cdf, ppf as expon_ppf  # noqa
 from .crystalball import pdf as crystalball_pdf, cdf as crystalball_cdf  # noqa
 from .t import pdf as t_pdf, cdf as t_cdf, ppf as t_ppf  # noqa

--- a/tests/test_cpoisson.py
+++ b/tests/test_cpoisson.py
@@ -1,0 +1,10 @@
+from numba_stats import poisson, cpoisson
+import numpy as np
+
+
+def test_cpoisson_cdf():
+    mu = np.array((0.1, 0.5, 1.0, 2.0))[:, np.newaxis]
+    k = np.arange(10)
+    got = cpoisson.cdf(k, mu)
+    expected = poisson.cdf(k, mu)
+    np.testing.assert_allclose(got, expected)

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -41,7 +41,7 @@ def test_deprecated():
         assert nbs.poisson_pmf is poisson.pmf
 
     with pytest.warns(VisibleDeprecationWarning):
-        assert nbs.cpoisson_pdf is cpoisson.pdf
+        assert nbs.cpoisson_cdf is cpoisson.cdf
 
     with pytest.warns(VisibleDeprecationWarning):
         assert nbs.expon_pdf is expon.pdf

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -53,26 +53,6 @@ def test_poisson_cdf():
     np.testing.assert_allclose(got, expected)
 
 
-def test_cpoisson_pdf():
-    from numba_stats import cpoisson
-
-    m = np.linspace(0.1, 3, 20)[:, np.newaxis]
-    k = np.arange(10)
-    got = cpoisson.pdf(k, m)
-    expected = sc.poisson.pmf(k, m)
-    np.testing.assert_allclose(got, expected)
-
-
-def test_cpoisson_cdf():
-    from numba_stats import cpoisson
-
-    m = np.linspace(0.1, 3, 20)[:, np.newaxis]
-    k = np.arange(10)
-    got = cpoisson.cdf(k, m)
-    expected = sc.poisson.cdf(k, m)
-    np.testing.assert_allclose(got, expected)
-
-
 def test_expon_pdf():
     from numba_stats import expon
 


### PR DESCRIPTION
@matthewkenzie 

The pdf of the continuous Poisson distribution, d cdf(x, mu)/ dx, cannot be expressed in tabulated functions:

d G(x, mu)/d x = ln(mu) G(x, mu) + mu T(3, x, mu)

where G(x, mu) is the upper incomplete gamma function and T(m, s, x) is a special case of the Meijer G-function,
see https://en.wikipedia.org/wiki/Incomplete_gamma_function#Derivatives

There is a Meijer G-function implemented in `mpmath`, but I don't know how to use it. I spend many hours on this and eventually gave up. If you want to fit weighted histograms, you don't need the continuous Poisson pdf anyway. The cost functions in iminuit already support fitting weighted histograms based on the SPD approach.

Feel free to submit another patch to implement the pdf for a continuous Poisson pdf, if you figure out how to implement it. I got nerd-sniped by this.