### PR TITLE
Add qnorm

### DIFF
--- a/src/numba_stats/_special.py
+++ b/src/numba_stats/_special.py
@@ -32,6 +32,7 @@ erfinv = get("erfinv", float64(float64))
 gammaincc = get("gammaincc", float64(float64, float64))
 stdtr = get("stdtr", float64(float64, float64))
 stdtrit = get("stdtrit", float64(float64, float64))
+hyp2f1 = get("hyp2f1", float64(float64, float64, float64, float64))
 
 # n-ary functions (double)
 voigt_profile = get("voigt_profile", float64(float64, float64, float64))

--- a/src/numba_stats/_special.py
+++ b/src/numba_stats/_special.py
@@ -5,8 +5,6 @@
 from numba.extending import get_cython_function_address
 from numba.types import WrapperAddressProtocol, float64
 import scipy.special.cython_special as cysp
-import numba as nb
-import numpy as np
 
 
 def get(name, signature):
@@ -33,27 +31,8 @@ erfinv = get("erfinv", float64(float64))
 # binary functions (double)
 gammaincc = get("gammaincc", float64(float64, float64))
 stdtrit = get("stdtrit", float64(float64, float64))
-hyp2f1 = get("hyp2f1", float64(float64, float64, float64, float64))
+stdtr = get("stdtr", float64(float64, float64))
 betainc = get("betainc", float64(float64, float64, float64))
-
-
-@nb.njit
-def stdtr(nu, t):
-    # supports real values for nu, while scipy.special.stdtr current does not
-    if nu <= 0:
-        return np.nan
-
-    if t == 0:
-        return 0.5
-
-    x = t if t < 0 else -t
-    z = nu / (nu + x * x)
-    p = 0.5 * betainc(0.5 * nu, 0.5, z)
-
-    if t < 0:
-        return p
-    return 1 - p
-
 
 # n-ary functions (double)
 voigt_profile = get("voigt_profile", float64(float64, float64, float64))

--- a/src/numba_stats/_special.py
+++ b/src/numba_stats/_special.py
@@ -33,6 +33,7 @@ gammaincc = get("gammaincc", float64(float64, float64))
 stdtr = get("stdtr", float64(float64, float64))
 stdtrit = get("stdtrit", float64(float64, float64))
 hyp2f1 = get("hyp2f1", float64(float64, float64, float64, float64))
+betainc = get("betainc", float64(float64, float64, float64))
 
 # n-ary functions (double)
 voigt_profile = get("voigt_profile", float64(float64, float64, float64))

--- a/src/numba_stats/_special.py
+++ b/src/numba_stats/_special.py
@@ -5,6 +5,8 @@
 from numba.extending import get_cython_function_address
 from numba.types import WrapperAddressProtocol, float64
 import scipy.special.cython_special as cysp
+import numba as nb
+import numpy as np
 
 
 def get(name, signature):
@@ -30,10 +32,28 @@ erfinv = get("erfinv", float64(float64))
 
 # binary functions (double)
 gammaincc = get("gammaincc", float64(float64, float64))
-stdtr = get("stdtr", float64(float64, float64))
 stdtrit = get("stdtrit", float64(float64, float64))
 hyp2f1 = get("hyp2f1", float64(float64, float64, float64, float64))
 betainc = get("betainc", float64(float64, float64, float64))
+
+
+@nb.njit
+def stdtr(nu, t):
+    # supports real values for nu, while scipy.special.stdtr current does not
+    if nu <= 0:
+        return np.nan
+
+    if t == 0:
+        return 0.5
+
+    x = t if t < 0 else -t
+    z = nu / (nu + x * x)
+    p = 0.5 * betainc(0.5 * nu, 0.5, z)
+
+    if t < 0:
+        return p
+    return 1 - p
+
 
 # n-ary functions (double)
 voigt_profile = get("voigt_profile", float64(float64, float64, float64))

--- a/src/numba_stats/qgaussian.py
+++ b/src/numba_stats/qgaussian.py
@@ -34,7 +34,13 @@ def _compute_cq(q):
     return np.nan
 
 
-@nb.vectorize
+_signatures = [
+    nb.float32(nb.float32, nb.float32, nb.float32, nb.float32),
+    nb.float64(nb.float64, nb.float64, nb.float64, nb.float64),
+]
+
+
+@nb.vectorize(_signatures)
 def pdf(x, q, mu, sigma):
     inv_scale = 1.0 / sigma
     z = (x - mu) * inv_scale
@@ -42,3 +48,11 @@ def pdf(x, q, mu, sigma):
     inv_scale /= c_q * np.sqrt(2)
     # beta = 1/2 for equivalence with normal dist. for q = 1
     return _qexp(-0.5 * (z ** 2), q) * inv_scale
+
+
+# from sympy import *
+# from matplotlib import pyplot as plt
+#
+# x = np.linspace(-5, 5)
+#
+# plt.plot(x, pdf(x, 1, 0, 1))

--- a/src/numba_stats/qgaussian.py
+++ b/src/numba_stats/qgaussian.py
@@ -1,6 +1,6 @@
 import numba as nb
 import numpy as np
-from math import gamma, lgamma
+from math import lgamma
 from ._special import hyp2f1
 from . import norm
 
@@ -58,15 +58,6 @@ def pdf(x, q, mu, sigma):
     return _qexp(-0.5 * z ** 2, q) * inv_scale
 
 
-# @nb.vectorize(_signatures)
-# def cdf(x, q, mu, sigma):
-#     inv_scale = 1.0 / sigma
-#     z = (x - mu) * inv_scale
-#     c_q = _compute_cq(q)
-#     alpha = 1.0 - q
-#     return hyp2f1(0.5, -1.0 / alpha, 1.5, 0.5 * z ** 2 * alpha) / c_q + 0.5
-
-
 @nb.vectorize(_signatures)
 def cdf(x, q, mu, sigma):
     if q < 1 or q > 2:
@@ -75,14 +66,8 @@ def cdf(x, q, mu, sigma):
     if q == 1:
         return norm.cdf(x, mu, sigma)
 
-    # 1 / (2 sigma^2) = 1 / (3 - q)
-    # sqrt((3 - q) / 2) = sigma
-
-    sigma *= np.sqrt(0.5 * (3.0 - q))
     inv_scale = 1.0 / sigma
     z = (x - mu) * inv_scale
-    nu = (3 - q) / (q - 1)
-
-    return 0.5 + z * gamma(0.5 * (nu + 1)) / np.sqrt(nu * np.pi) / gamma(
-        0.5 * nu
-    ) * hyp2f1(0.5, 0.5 * (nu + 1), 1.5, -(z ** 2) / nu)
+    c_q = _compute_cq(q)
+    qm1 = q - 1.0
+    return 0.5 + z * hyp2f1(0.5, 1.0 / qm1, 1.5, -0.5 * z ** 2 * qm1) / c_q

--- a/src/numba_stats/qgaussian.py
+++ b/src/numba_stats/qgaussian.py
@@ -1,7 +1,7 @@
 import numba as nb
 import numpy as np
 from math import lgamma
-from ._special import betainc
+from ._special import stdtr
 from . import norm
 
 
@@ -40,23 +40,6 @@ def _compute_cq(q):
     return np.nan
 
 
-@nb.njit
-def _stdtr(k, t):
-    if k <= 0:
-        return np.nan
-
-    if t == 0:
-        return 0.5
-
-    x = t if t < 0 else -t
-    z = k / (k + x * x)
-    p = 0.5 * betainc(0.5 * k, 0.5, z)
-
-    if t < 0:
-        return p
-    return 1 - p
-
-
 _signatures = [
     nb.float32(nb.float32, nb.float32, nb.float32, nb.float32),
     nb.float64(nb.float64, nb.float64, nb.float64, nb.float64),
@@ -93,4 +76,4 @@ def cdf(x, q, mu, sigma):
     inv_scale = 1.0 / sigma
     z = (x - mu) * inv_scale
 
-    return _stdtr(nu, z)
+    return stdtr(nu, z)

--- a/src/numba_stats/qgaussian.py
+++ b/src/numba_stats/qgaussian.py
@@ -1,0 +1,44 @@
+import numba as nb
+import numpy as np
+from math import gamma
+
+
+@nb.njit
+def _qexp(x, q):
+    if q == 1:
+        return np.exp(x)
+    alpha = 1.0 - q
+    le = np.log(1.0 + alpha * x) / alpha
+    return np.exp(le)
+
+
+@nb.njit
+def _compute_cq(q):
+    sqrt_pi = np.sqrt(np.pi)
+    alpha = 1.0 - q
+    if q == 1:
+        return sqrt_pi
+    if q < 1:
+        return (
+            2.0
+            * sqrt_pi
+            * gamma(1.0 / alpha)
+            / ((3.0 - q) * np.sqrt(alpha) * gamma(0.5 * (3.0 - q) / alpha))
+        )
+    if q < 3:
+        return (
+            sqrt_pi
+            * gamma(-0.5 * (3.0 - q) / alpha)
+            / (np.sqrt(-alpha) * gamma(-1.0 / alpha))
+        )
+    return np.nan
+
+
+@nb.vectorize
+def pdf(x, q, mu, sigma):
+    inv_scale = 1.0 / sigma
+    z = (x - mu) * inv_scale
+    c_q = _compute_cq(q)
+    inv_scale /= c_q * np.sqrt(2)
+    # beta = 1/2 for equivalence with normal dist. for q = 1
+    return _qexp(-0.5 * (z ** 2), q) * inv_scale

--- a/src/numba_stats/qgaussian.py
+++ b/src/numba_stats/qgaussian.py
@@ -1,6 +1,8 @@
 import numba as nb
 import numpy as np
-from math import gamma
+from math import gamma, lgamma
+from ._special import hyp2f1
+from . import norm
 
 
 @nb.njit
@@ -8,28 +10,32 @@ def _qexp(x, q):
     if q == 1:
         return np.exp(x)
     alpha = 1.0 - q
-    le = np.log(1.0 + alpha * x) / alpha
+    arg = 1.0 + alpha * x
+    if arg <= 0:
+        return 0
+    le = np.log(arg) / alpha
     return np.exp(le)
 
 
 @nb.njit
 def _compute_cq(q):
-    sqrt_pi = np.sqrt(np.pi)
+    # beta = 1/2 for equivalence with normal distribution for q = 1
+    const = np.sqrt(2 * np.pi)
     alpha = 1.0 - q
     if q == 1:
-        return sqrt_pi
+        return const
     if q < 1:
         return (
             2.0
-            * sqrt_pi
-            * gamma(1.0 / alpha)
-            / ((3.0 - q) * np.sqrt(alpha) * gamma(0.5 * (3.0 - q) / alpha))
+            * const
+            / ((3.0 - q) * np.sqrt(alpha))
+            * np.exp(lgamma(1.0 / alpha) - lgamma(0.5 * (3.0 - q) / alpha))
         )
     if q < 3:
         return (
-            sqrt_pi
-            * gamma(-0.5 * (3.0 - q) / alpha)
-            / (np.sqrt(-alpha) * gamma(-1.0 / alpha))
+            const
+            / np.sqrt(-alpha)
+            * np.exp(lgamma(-0.5 * (3.0 - q) / alpha) - lgamma(-1.0 / alpha))
         )
     return np.nan
 
@@ -45,14 +51,38 @@ def pdf(x, q, mu, sigma):
     inv_scale = 1.0 / sigma
     z = (x - mu) * inv_scale
     c_q = _compute_cq(q)
-    inv_scale /= c_q * np.sqrt(2)
-    # beta = 1/2 for equivalence with normal dist. for q = 1
-    return _qexp(-0.5 * (z ** 2), q) * inv_scale
+    inv_scale /= c_q
+    # beta = 1/2 for equivalence with normal distribution for q = 1
+    if q == 1.0:
+        return np.exp(-0.5 * z ** 2) * inv_scale
+    return _qexp(-0.5 * z ** 2, q) * inv_scale
 
 
-# from sympy import *
-# from matplotlib import pyplot as plt
-#
-# x = np.linspace(-5, 5)
-#
-# plt.plot(x, pdf(x, 1, 0, 1))
+# @nb.vectorize(_signatures)
+# def cdf(x, q, mu, sigma):
+#     inv_scale = 1.0 / sigma
+#     z = (x - mu) * inv_scale
+#     c_q = _compute_cq(q)
+#     alpha = 1.0 - q
+#     return hyp2f1(0.5, -1.0 / alpha, 1.5, 0.5 * z ** 2 * alpha) / c_q + 0.5
+
+
+@nb.vectorize(_signatures)
+def cdf(x, q, mu, sigma):
+    if q < 1 or q > 2:
+        raise ValueError("q < 1 or q >= 3 are not supported")
+
+    if q == 1:
+        return norm.cdf(x, mu, sigma)
+
+    # 1 / (2 sigma^2) = 1 / (3 - q)
+    # sqrt((3 - q) / 2) = sigma
+
+    sigma *= np.sqrt(0.5 * (3.0 - q))
+    inv_scale = 1.0 / sigma
+    z = (x - mu) * inv_scale
+    nu = (3 - q) / (q - 1)
+
+    return 0.5 + z * gamma(0.5 * (nu + 1)) / np.sqrt(nu * np.pi) / gamma(
+        0.5 * nu
+    ) * hyp2f1(0.5, 0.5 * (nu + 1), 1.5, -(z ** 2) / nu)

--- a/src/numba_stats/qgaussian.py
+++ b/src/numba_stats/qgaussian.py
@@ -39,6 +39,21 @@ def _compute_cq(q):
     return np.nan
 
 
+@nb.njit
+def _df_sigma(q, sigma):
+    # https://en.wikipedia.org/wiki/Q-Gaussian_distribution
+    # relation to Student's t-distribution
+
+    # 1/(2 sigma^2) = 1 / (3 - q)
+    # 2 sigma^2 = 3 - q
+    # sigma = sqrt((3 - q)/2)
+
+    df = (3 - q) / (q - 1)
+    sigma /= np.sqrt(0.5 * (3 - q))
+
+    return df, sigma
+
+
 _signatures = [
     nb.float32(nb.float32, nb.float32, nb.float32, nb.float32),
     nb.float64(nb.float64, nb.float64, nb.float64, nb.float64),
@@ -65,12 +80,7 @@ def cdf(x, q, mu, sigma):
     if q == 1:
         return norm.cdf(x, mu, sigma)
 
-    # 1/(2 sigma^2) = 1 / (3 - q)
-    # 2 sigma^2 = 3 - q
-    # sigma = sqrt((3 - q)/2)
-
-    df = (3 - q) / (q - 1)
-    sigma /= np.sqrt(0.5 * (3 - q))
+    df, sigma = _df_sigma(q, sigma)
 
     return t.cdf(x, df, mu, sigma)
 
@@ -83,11 +93,6 @@ def ppf(x, q, mu, sigma):
     if q == 1:
         return norm.ppf(x, mu, sigma)
 
-    # 1/(2 sigma^2) = 1 / (3 - q)
-    # 2 sigma^2 = 3 - q
-    # sigma = sqrt((3 - q)/2)
-
-    df = (3 - q) / (q - 1)
-    sigma /= np.sqrt(0.5 * (3 - q))
+    df, sigma = _df_sigma(q, sigma)
 
     return t.ppf(x, df, mu, sigma)

--- a/src/numba_stats/qgaussian.py
+++ b/src/numba_stats/qgaussian.py
@@ -1,8 +1,7 @@
 import numba as nb
 import numpy as np
 from math import lgamma
-from ._special import stdtr
-from . import norm
+from . import norm, t
 
 
 @nb.njit
@@ -70,10 +69,25 @@ def cdf(x, q, mu, sigma):
     # 2 sigma^2 = 3 - q
     # sigma = sqrt((3 - q)/2)
 
-    nu = (3 - q) / (q - 1)
+    df = (3 - q) / (q - 1)
     sigma /= np.sqrt(0.5 * (3 - q))
 
-    inv_scale = 1.0 / sigma
-    z = (x - mu) * inv_scale
+    return t.cdf(x, df, mu, sigma)
 
-    return stdtr(nu, z)
+
+@nb.vectorize(_signatures)
+def ppf(x, q, mu, sigma):
+    if q < 1 or q > 3:
+        raise ValueError("q < 1 or q > 3 are not supported")
+
+    if q == 1:
+        return norm.ppf(x, mu, sigma)
+
+    # 1/(2 sigma^2) = 1 / (3 - q)
+    # 2 sigma^2 = 3 - q
+    # sigma = sqrt((3 - q)/2)
+
+    df = (3 - q) / (q - 1)
+    sigma /= np.sqrt(0.5 * (3 - q))
+
+    return t.ppf(x, df, mu, sigma)

--- a/src/numba_stats/t.py
+++ b/src/numba_stats/t.py
@@ -1,11 +1,11 @@
 import numba as nb
 import numpy as np
 from ._special import stdtr, stdtrit
-from math import lgamma as gammaln
+from math import lgamma
 
 _signatures = [
-    nb.float32(nb.float32, nb.int32, nb.float32, nb.float32),
-    nb.float64(nb.float64, nb.intp, nb.float64, nb.float64),
+    nb.float32(nb.float32, nb.float32, nb.float32, nb.float32),
+    nb.float64(nb.float64, nb.float64, nb.float64, nb.float64),
 ]
 
 
@@ -16,7 +16,7 @@ def pdf(x, df, mu, sigma):
     """
     z = (x - mu) / sigma
     k = 0.5 * (df + 1)
-    p = np.exp(gammaln(k) - gammaln(0.5 * df))
+    p = np.exp(lgamma(k) - lgamma(0.5 * df))
     p /= np.sqrt(df * np.pi) * (1 + (z ** 2) / df) ** k
     return p / sigma
 

--- a/src/numba_stats/t.py
+++ b/src/numba_stats/t.py
@@ -4,8 +4,8 @@ from ._special import stdtr, stdtrit
 from math import lgamma as gammaln
 
 _signatures = [
-    nb.float32(nb.float32, nb.float32, nb.float32, nb.float32),
-    nb.float64(nb.float64, nb.float64, nb.float64, nb.float64),
+    nb.float32(nb.float32, nb.int32, nb.float32, nb.float32),
+    nb.float64(nb.float64, nb.intp, nb.float64, nb.float64),
 ]
 
 

--- a/tests/test_qgaussian.py
+++ b/tests/test_qgaussian.py
@@ -3,7 +3,7 @@ import numpy as np
 import pytest
 
 
-@pytest.mark.parametrize("nu", (0.1, 1.0, 2.0))
+@pytest.mark.parametrize("nu", (1, 3, 10))
 def test_qgaussian_pdf(nu):
     x = np.linspace(-5, 5)
 

--- a/tests/test_qgaussian.py
+++ b/tests/test_qgaussian.py
@@ -1,6 +1,7 @@
 from numba_stats import qgaussian, t, norm
 import numpy as np
 import pytest
+from scipy.integrate import quad
 
 
 def q_sigma(nu, sigma):
@@ -32,23 +33,22 @@ def test_qgaussian_cdf_vs_norm():
     np.testing.assert_allclose(got, expected)
 
 
-@pytest.mark.parametrize("nu", (1, 3, 10))
+@pytest.mark.parametrize("nu", np.arange(1, 11))
 def test_qgaussian_pdf_vs_t(nu):
     x = np.linspace(-5, 5)
-    q, sigma = q_sigma(nu, 1)
+    q, sigma = q_sigma(nu, 1.2)
 
-    expected = t.pdf(x, nu, 0, 1)
-    got = qgaussian.pdf(x, q, 0, sigma)
+    expected = t.pdf(x, nu, 0.1, 1.2)
+    got = qgaussian.pdf(x, q, 0.1, sigma)
 
     np.testing.assert_allclose(got, expected)
 
 
-@pytest.mark.parametrize("nu", (1, 3, 10))
-def test_qgaussian_cdf_vs_t(nu):
-    x = np.linspace(-5, 5)
-    q, sigma = q_sigma(nu, 1)
+@pytest.mark.parametrize("q", (1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.9, 2.0, 2.5, 2.9))
+def test_qgaussian_cdf(q):
+    x = np.linspace(-5, 5, 10)
 
-    expected = t.cdf(x, nu, 0, 1)
-    got = qgaussian.cdf(x, q, 0, sigma)
+    expected = [quad(lambda y: qgaussian.pdf(y, q, 0.1, 1.2), 0, xi)[0] for xi in x]
+    got = qgaussian.cdf(x, q, 0.1, 1.2) - qgaussian.cdf(0, q, 0.1, 1.2)
 
     np.testing.assert_allclose(got, expected)

--- a/tests/test_qgaussian.py
+++ b/tests/test_qgaussian.py
@@ -52,3 +52,17 @@ def test_qgaussian_cdf(q):
     got = qgaussian.cdf(x, q, 0.1, 1.2) - qgaussian.cdf(0, q, 0.1, 1.2)
 
     np.testing.assert_allclose(got, expected)
+
+
+@pytest.mark.parametrize("q", (1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.9, 2.0, 2.5, 2.9))
+def test_qgaussian_ppf(q):
+    x = np.linspace(-5, 5, 10)
+
+    def f(x):
+        p = qgaussian.cdf(x, q, 2, 3)
+        return qgaussian.ppf(p, q, 2, 3)
+
+    expected = x
+    got = f(x)
+
+    np.testing.assert_allclose(got, expected)

--- a/tests/test_qgaussian.py
+++ b/tests/test_qgaussian.py
@@ -1,0 +1,22 @@
+from numba_stats import qgaussian, t
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize("nu", (0.1, 1.0, 2.0))
+def test_qgaussian_pdf(nu):
+    x = np.linspace(-5, 5)
+
+    # https://en.wikipedia.org/wiki/Q-Gaussian_distribution
+    # relation to Student's t-distribution
+    q = (nu + 3) / (nu + 1)
+    beta = 1 / (3 - q)
+
+    # 2 beta x^2 = (x/sigma)^2
+    # 2 beta = 1/sigma^2
+    # sigma = 1/sqrt(2 beta)
+
+    expected = t.pdf(x, nu, 0, 1)
+    got = qgaussian.pdf(x, q, 0, 1 / np.sqrt(2 * beta))
+
+    np.testing.assert_allclose(got, expected)

--- a/tests/test_qgaussian.py
+++ b/tests/test_qgaussian.py
@@ -1,22 +1,54 @@
-from numba_stats import qgaussian, t
+from numba_stats import qgaussian, t, norm
 import numpy as np
 import pytest
 
 
-@pytest.mark.parametrize("nu", (1, 3, 10))
-def test_qgaussian_pdf(nu):
-    x = np.linspace(-5, 5)
-
+def q_sigma(nu, sigma):
     # https://en.wikipedia.org/wiki/Q-Gaussian_distribution
     # relation to Student's t-distribution
-    q = (nu + 3) / (nu + 1)
-    beta = 1 / (3 - q)
 
-    # 2 beta x^2 = (x/sigma)^2
-    # 2 beta = 1/sigma^2
-    # sigma = 1/sqrt(2 beta)
+    # 1 / (2 sigma^2) = 1 / (3 - q)
+    # sqrt((3 - q) / 2) = sigma
+
+    q = (nu + 3.0) / (nu + 1.0)
+    return q, sigma * np.sqrt(0.5 * (3.0 - q))
+
+
+def test_qgaussian_pdf_vs_norm():
+    x = np.linspace(-5, 5)
+
+    expected = norm.pdf(x, 0.5, 1.2)
+    got = qgaussian.pdf(x, 1, 0.5, 1.2)
+
+    np.testing.assert_allclose(got, expected)
+
+
+def test_qgaussian_cdf_vs_norm():
+    x = np.linspace(-5, 5)
+
+    expected = norm.cdf(x, 0.5, 1.2)
+    got = qgaussian.cdf(x, 1, 0.5, 1.2)
+
+    np.testing.assert_allclose(got, expected)
+
+
+@pytest.mark.parametrize("nu", (1, 3, 10))
+def test_qgaussian_pdf_vs_t(nu):
+    x = np.linspace(-5, 5)
+    q, sigma = q_sigma(nu, 1)
 
     expected = t.pdf(x, nu, 0, 1)
-    got = qgaussian.pdf(x, q, 0, 1 / np.sqrt(2 * beta))
+    got = qgaussian.pdf(x, q, 0, sigma)
+
+    np.testing.assert_allclose(got, expected)
+
+
+@pytest.mark.parametrize("nu", (1, 3, 10))
+def test_qgaussian_cdf_vs_t(nu):
+    x = np.linspace(-5, 5)
+    q, sigma = q_sigma(nu, 1)
+
+    expected = t.cdf(x, nu, 0, 1)
+    got = qgaussian.cdf(x, q, 0, sigma)
 
     np.testing.assert_allclose(got, expected)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -81,33 +81,6 @@ def test_expon_ppf():
     np.testing.assert_allclose(got, expected)
 
 
-def test_t_pdf():
-    from numba_stats import t
-
-    x = np.linspace(-5, 5, 10)
-    got = t.pdf(x, 1.5, 2, 3)
-    expected = sc.t.pdf(x, 1.5, 2, 3)
-    np.testing.assert_allclose(got, expected)
-
-
-def test_t_cdf():
-    from numba_stats import t
-
-    x = np.linspace(-5, 5, 10)
-    got = t.cdf(x, 1.5, 2, 3)
-    expected = sc.t.cdf(x, 1.5, 2, 3)
-    np.testing.assert_allclose(got, expected)
-
-
-def test_t_ppf():
-    from numba_stats import t
-
-    x = np.linspace(0, 1, 10)
-    got = t.ppf(x, 1.5, 2, 3)
-    expected = sc.t.ppf(x, 1.5, 2, 3)
-    np.testing.assert_allclose(got, expected)
-
-
 def test_voigt_pdf():
     from numba_stats import voigt
 

--- a/tests/test_t.py
+++ b/tests/test_t.py
@@ -1,0 +1,28 @@
+import scipy.stats as sc
+import numpy as np
+from numba_stats import t
+import pytest
+
+
+@pytest.mark.parametrize("nu", (1, 3, 10))
+def test_t_pdf(nu):
+    x = np.linspace(-5, 5, 10)
+    got = t.pdf(x, nu, 2, 3)
+    expected = sc.t.pdf(x, nu, 2, 3)
+    np.testing.assert_allclose(got, expected)
+
+
+@pytest.mark.parametrize("nu", (1, 3, 10))
+def test_t_cdf(nu):
+    x = np.linspace(-5, 5, 10)
+    got = t.cdf(x, nu, 2, 3)
+    expected = sc.t.cdf(x, nu, 2, 3)
+    np.testing.assert_allclose(got, expected)
+
+
+@pytest.mark.parametrize("nu", (1, 3, 10))
+def test_t_ppf(nu):
+    x = np.linspace(0, 1, 10)
+    got = t.ppf(x, nu, 2, 3)
+    expected = sc.t.ppf(x, nu, 2, 3)
+    np.testing.assert_allclose(got, expected)

--- a/tests/test_t.py
+++ b/tests/test_t.py
@@ -4,25 +4,25 @@ from numba_stats import t
 import pytest
 
 
-@pytest.mark.parametrize("nu", (1, 3, 10))
-def test_t_pdf(nu):
+@pytest.mark.parametrize("df", (1, 1.5, 2, 3, 4, 5.5, 10))
+def test_t_pdf(df):
     x = np.linspace(-5, 5, 10)
-    got = t.pdf(x, nu, 2, 3)
-    expected = sc.t.pdf(x, nu, 2, 3)
+    got = t.pdf(x, df, 2, 3)
+    expected = sc.t.pdf(x, df, 2, 3)  # supports real-valued df
     np.testing.assert_allclose(got, expected)
 
 
-@pytest.mark.parametrize("nu", (1, 3, 10))
-def test_t_cdf(nu):
+@pytest.mark.parametrize("df", (1, 1.5, 3, 5.5, 10))
+def test_t_cdf(df):
     x = np.linspace(-5, 5, 10)
-    got = t.cdf(x, nu, 2, 3)
-    expected = sc.t.cdf(x, nu, 2, 3)
+    got = t.cdf(x, df, 2, 3)
+    expected = sc.t.cdf(x, df, 2, 3)  # supports real-valued df
     np.testing.assert_allclose(got, expected)
 
 
-@pytest.mark.parametrize("nu", (1, 3, 10))
-def test_t_ppf(nu):
+@pytest.mark.parametrize("df", (1, 1.5, 3, 5.5, 10))
+def test_t_ppf(df):
     x = np.linspace(0, 1, 10)
-    got = t.ppf(x, nu, 2, 3)
-    expected = sc.t.ppf(x, nu, 2, 3)
+    got = t.ppf(x, df, 2, 3)
+    expected = sc.t.ppf(x, df, 2, 3)  # supports real-valued df
     np.testing.assert_allclose(got, expected)


### PR DESCRIPTION
The q-gaussian is derived from the Tsallis entropy, which generalizes normal entropy. Mathematically, it is related to the student's t distribution. This implementation uses that to defer the computation of the cdf and ppf to student's t.

After some confusion, I realized that the Student's t implementation in SciPy already supports a real-valued df parameter, which makes this possible.