### PR TITLE
Added logpdf to norm and lognorm

### DIFF
--- a/src/numba_stats/lognorm.py
+++ b/src/numba_stats/lognorm.py
@@ -14,12 +14,20 @@ def pdf(x, s, loc, scale):
     """
     Return probability density of lognormal distribution.
     """
+    return np.exp(logpdf(x, s, loc, scale))
+
+
+@nb.vectorize(_signatures, cache=True)
+def logpdf(x, s, loc, scale):
+    """
+    Return log of probability density of lognormal distribution.
+    """
     z = (x - loc) / scale
     if z <= 0:
-        return 0.0
+        return -np.inf
     c = np.sqrt(2 * np.pi)
     log_pdf = -0.5 * np.log(z) ** 2 / s ** 2 - np.log(s * z * c)
-    return np.exp(log_pdf) / scale
+    return log_pdf - np.log(scale)
 
 
 @nb.vectorize(_signatures, cache=True)
@@ -40,16 +48,3 @@ def ppf(p, s, loc, scale):
     """
     z = np.exp(s * _ppf(p))
     return scale * z + loc
-
-
-@nb.vectorize(_signatures, cache=True)
-def logpdf(x, s, loc, scale):
-    """
-    Return log probability density of lognormal distribution.
-    """
-    z = (x - loc) / scale
-    if z <= 0:
-        return -np.inf
-    c = np.sqrt(2 * np.pi)
-    log_pdf = -0.5 * np.log(z) ** 2 / s ** 2 - np.log(s * z * c)
-    return log_pdf - np.log(scale)

--- a/src/numba_stats/lognorm.py
+++ b/src/numba_stats/lognorm.py
@@ -12,7 +12,7 @@ _signatures = [
 @nb.vectorize(_signatures, cache=True)
 def pdf(x, s, loc, scale):
     """
-    Return probability density of normal distribution.
+    Return probability density of lognormal distribution.
     """
     z = (x - loc) / scale
     if z <= 0:
@@ -25,7 +25,7 @@ def pdf(x, s, loc, scale):
 @nb.vectorize(_signatures, cache=True)
 def cdf(x, s, loc, scale):
     """
-    Evaluate cumulative distribution function of normal distribution.
+    Evaluate cumulative distribution function of lognormal distribution.
     """
     z = (x - loc) / scale
     if z <= 0:
@@ -36,7 +36,19 @@ def cdf(x, s, loc, scale):
 @nb.vectorize(_signatures)
 def ppf(p, s, loc, scale):
     """
-    Return quantile of normal distribution for given probability.
+    Return quantile of lognormal distribution for given probability.
     """
     z = np.exp(s * _ppf(p))
     return scale * z + loc
+
+@nb.vectorize(_signatures, cache=True)
+def logpdf(x, s, loc, scale):
+    """
+    Return log probability density of lognormal distribution.
+    """
+    z = (x - loc) / scale
+    if z <= 0:
+        return -np.inf
+    c = np.sqrt(2 * np.pi)
+    log_pdf = -0.5 * np.log(z) ** 2 / s ** 2 - np.log(s * z * c)
+    return log_pdf - np.log(scale)

--- a/src/numba_stats/lognorm.py
+++ b/src/numba_stats/lognorm.py
@@ -41,6 +41,7 @@ def ppf(p, s, loc, scale):
     z = np.exp(s * _ppf(p))
     return scale * z + loc
 
+
 @nb.vectorize(_signatures, cache=True)
 def logpdf(x, s, loc, scale):
     """

--- a/src/numba_stats/norm.py
+++ b/src/numba_stats/norm.py
@@ -5,15 +5,8 @@ from math import erf as _erf
 
 
 @nb.njit(cache=True)
-def _pdf(z):
-    c = 1.0 / np.sqrt(2 * np.pi)
-    return np.exp(-0.5 * z ** 2) * c
-
-
-@nb.njit(cache=True)
 def _logpdf(z):
-    c = 1.0 / np.sqrt(2 * np.pi)
-    return (-0.5 * z ** 2) + np.log(c)
+    return -0.5 * (z ** 2 + np.log(2 * np.pi))
 
 
 @nb.njit(cache=True)
@@ -34,12 +27,23 @@ _signatures = [
 
 
 @nb.vectorize(_signatures, cache=True)
+def logpdf(x, mu, sigma):
+    """
+    Return log of probability density of normal distribution.
+    """
+    z = (x - mu) / sigma
+    return _logpdf(z) - np.log(sigma)
+
+
+@nb.vectorize(_signatures, cache=True)
 def pdf(x, mu, sigma):
     """
     Return probability density of normal distribution.
     """
+    # cannot call logpdf directly here, because nb.vectorize does not generate
+    # inlinable code
     z = (x - mu) / sigma
-    return _pdf(z) / sigma
+    return np.exp(_logpdf(z)) / sigma
 
 
 @nb.vectorize(_signatures, cache=True)
@@ -58,12 +62,3 @@ def ppf(p, mu, sigma):
     """
     z = _ppf(p)
     return sigma * z + mu
-
-
-@nb.vectorize(_signatures, cache=True)
-def logpdf(x, mu, sigma):
-    """
-    Return log of probability density of normal distribution.
-    """
-    z = (x - mu) / sigma
-    return _logpdf(z) - np.log(sigma)

--- a/src/numba_stats/norm.py
+++ b/src/numba_stats/norm.py
@@ -9,6 +9,7 @@ def _pdf(z):
     c = 1.0 / np.sqrt(2 * np.pi)
     return np.exp(-0.5 * z ** 2) * c
 
+
 @nb.njit(cache=True)
 def _logpdf(z):
     c = 1.0 / np.sqrt(2 * np.pi)

--- a/src/numba_stats/norm.py
+++ b/src/numba_stats/norm.py
@@ -9,6 +9,11 @@ def _pdf(z):
     c = 1.0 / np.sqrt(2 * np.pi)
     return np.exp(-0.5 * z ** 2) * c
 
+@nb.njit(cache=True)
+def _logpdf(z):
+    c = 1.0 / np.sqrt(2 * np.pi)
+    return (-0.5 * z ** 2) + np.log(c)
+
 
 @nb.njit(cache=True)
 def _cdf(z):
@@ -52,3 +57,12 @@ def ppf(p, mu, sigma):
     """
     z = _ppf(p)
     return sigma * z + mu
+
+
+@nb.vectorize(_signatures, cache=True)
+def logpdf(x, mu, sigma):
+    """
+    Return log of probability density of normal distribution.
+    """
+    z = (x - mu) / sigma
+    return _logpdf(z) - np.log(sigma)

--- a/tests/test_lognorm.py
+++ b/tests/test_lognorm.py
@@ -10,6 +10,14 @@ def test_lognorm_pdf():
     expected = sc.lognorm.pdf(x, 1.5, 0.1, 1.2)
     np.testing.assert_allclose(got, expected)
 
+def test_lognorm_logpdf():
+    from numba_stats import lognorm
+
+    x = np.linspace(0, 5, 10)
+    got = lognorm.logpdf(x, 1.5, 0.1, 1.2)
+    expected = sc.lognorm.logpdf(x, 1.5, 0.1, 1.2)
+    np.testing.assert_allclose(got, expected)
+
 
 def test_lognorm_cdf():
     from numba_stats import lognorm

--- a/tests/test_lognorm.py
+++ b/tests/test_lognorm.py
@@ -10,6 +10,7 @@ def test_lognorm_pdf():
     expected = sc.lognorm.pdf(x, 1.5, 0.1, 1.2)
     np.testing.assert_allclose(got, expected)
 
+
 def test_lognorm_logpdf():
     from numba_stats import lognorm
 

--- a/tests/test_norm.py
+++ b/tests/test_norm.py
@@ -11,6 +11,15 @@ def test_norm_pdf():
     np.testing.assert_allclose(got, expected)
 
 
+def test_norm_logpdf():
+    from numba_stats import norm
+
+    x = np.linspace(-5, 5, 10)
+    got = norm.logpdf(x, 1, 2)
+    expected = sc.norm.logpdf(x, 1, 2)
+    np.testing.assert_allclose(got, expected)
+
+
 def test_norm_cdf():
     from numba_stats import norm
 

--- a/tests/test_truncnorm.py
+++ b/tests/test_truncnorm.py
@@ -1,5 +1,30 @@
 import numpy as np
-from numba_stats import truncnorm, norm
+from numba_stats import truncnorm
+import scipy.stats as sc
+from scipy.integrate import quad
+import pytest
+
+
+@pytest.mark.parametrize("mu", (0, -1, 1))
+@pytest.mark.parametrize("sigma", (1, 0.5, 2))
+def test_truncnorm(mu, sigma):
+    got = quad(lambda x: truncnorm.pdf(x, -1, 1, mu, sigma), -10, 10)[0]
+    expected = 1.0
+    np.testing.assert_allclose(got, expected)
+
+
+def test_logpdf():
+    x = np.linspace(-1, 5, 10)
+    xmin = 1
+    xmax = 4
+    mu = 2
+    sigma = 3
+    got = truncnorm.logpdf(x, xmin, xmax, mu, sigma)
+    z = (x - mu) / sigma
+    zmin = (xmin - mu) / sigma
+    zmax = (xmax - mu) / sigma
+    expected = sc.truncnorm.logpdf(z, zmin, zmax) - np.log(sigma)
+    np.testing.assert_allclose(got, expected)
 
 
 def test_pdf():
@@ -9,11 +34,10 @@ def test_pdf():
     mu = 2
     sigma = 3
     got = truncnorm.pdf(x, xmin, xmax, mu, sigma)
-    expected = norm.pdf(x, mu, sigma) / (
-        norm.cdf(xmax, mu, sigma) - norm.cdf(xmin, mu, sigma)
-    )
-    expected[x < xmin] = 0
-    expected[x > xmax] = 0
+    z = (x - mu) / sigma
+    zmin = (xmin - mu) / sigma
+    zmax = (xmax - mu) / sigma
+    expected = sc.truncnorm.pdf(z, zmin, zmax) / sigma
     np.testing.assert_allclose(got, expected)
 
 
@@ -24,11 +48,10 @@ def test_cdf():
     mu = 2
     sigma = 3
     got = truncnorm.cdf(x, xmin, xmax, mu, sigma)
-    expected = (norm.cdf(x, mu, sigma) - norm.cdf(xmin, mu, sigma)) / (
-        norm.cdf(xmax, mu, sigma) - norm.cdf(xmin, mu, sigma)
-    )
-    expected[x < xmin] = 0
-    expected[x > xmax] = 1
+    z = (x - mu) / sigma
+    zmin = (xmin - mu) / sigma
+    zmax = (xmax - mu) / sigma
+    expected = sc.truncnorm.cdf(z, zmin, zmax)
     np.testing.assert_allclose(got, expected)
 
 


### PR DESCRIPTION
I have added logpdf to the lognormal and the normal.  Also to the test scripts.  Reason is that logs of pdf are used all the time in eg minuit log likelihood fits and this should speed up parameter scans tremendously.  I have zero experience making pull requests, I hope I did not screw it up.