### PR TITLE
Fix NumbaWarning: Compilation is falling back to object mode

### DIFF
--- a/src/numba_stats/lognorm.py
+++ b/src/numba_stats/lognorm.py
@@ -10,6 +10,14 @@ _signatures = [
 
 
 @nb.vectorize(_signatures, cache=True)
+def pdf(x, s, loc, scale):
+    """
+    Return probability density of lognormal distribution.
+    """
+    return np.exp(logpdf(x, s, loc, scale))
+
+
+@nb.vectorize(_signatures, cache=True)
 def logpdf(x, s, loc, scale):
     """
     Return log of probability density of lognormal distribution.
@@ -20,14 +28,6 @@ def logpdf(x, s, loc, scale):
     c = np.sqrt(2 * np.pi)
     log_pdf = -0.5 * np.log(z) ** 2 / s ** 2 - np.log(s * z * c)
     return log_pdf - np.log(scale)
-
-
-@nb.vectorize(_signatures, cache=True)
-def pdf(x, s, loc, scale):
-    """
-    Return probability density of lognormal distribution.
-    """
-    return np.exp(logpdf(x, s, loc, scale))
 
 
 @nb.vectorize(_signatures, cache=True)

--- a/src/numba_stats/lognorm.py
+++ b/src/numba_stats/lognorm.py
@@ -9,11 +9,8 @@ _signatures = [
 ]
 
 
-@nb.vectorize(_signatures, cache=True)
-def logpdf(x, s, loc, scale):
-    """
-    Return log of probability density of lognormal distribution.
-    """
+@nb.njit(_signatures, cache=True)
+def _logpdf(x, s, loc, scale):
     z = (x - loc) / scale
     if z <= 0:
         return -np.inf
@@ -23,11 +20,19 @@ def logpdf(x, s, loc, scale):
 
 
 @nb.vectorize(_signatures, cache=True)
+def logpdf(x, s, loc, scale):
+    """
+    Return log of probability density of lognormal distribution.
+    """
+    return _logpdf(x, s, loc, scale)
+
+
+@nb.vectorize(_signatures, cache=True)
 def pdf(x, s, loc, scale):
     """
     Return probability density of lognormal distribution.
     """
-    return np.exp(logpdf(x, s, loc, scale))
+    return np.exp(_logpdf(x, s, loc, scale))
 
 
 @nb.vectorize(_signatures, cache=True)

--- a/src/numba_stats/lognorm.py
+++ b/src/numba_stats/lognorm.py
@@ -3,13 +3,7 @@ import numpy as np
 from .norm import _cdf, _ppf
 
 
-_signatures = [
-    nb.float32(nb.float32, nb.float32, nb.float32, nb.float32),
-    nb.float64(nb.float64, nb.float64, nb.float64, nb.float64),
-]
-
-
-@nb.njit(_signatures, cache=True)
+@nb.njit(cache=True)
 def _logpdf(x, s, loc, scale):
     z = (x - loc) / scale
     if z <= 0:
@@ -17,6 +11,12 @@ def _logpdf(x, s, loc, scale):
     c = np.sqrt(2 * np.pi)
     log_pdf = -0.5 * np.log(z) ** 2 / s ** 2 - np.log(s * z * c)
     return log_pdf - np.log(scale)
+
+
+_signatures = [
+    nb.float32(nb.float32, nb.float32, nb.float32, nb.float32),
+    nb.float64(nb.float64, nb.float64, nb.float64, nb.float64),
+]
 
 
 @nb.vectorize(_signatures, cache=True)
@@ -46,7 +46,7 @@ def cdf(x, s, loc, scale):
     return _cdf(np.log(z) / s)
 
 
-@nb.vectorize(_signatures)
+@nb.vectorize(_signatures)  # cannot be cached because of call to _ppf
 def ppf(p, s, loc, scale):
     """
     Return quantile of lognormal distribution for given probability.

--- a/src/numba_stats/lognorm.py
+++ b/src/numba_stats/lognorm.py
@@ -10,14 +10,6 @@ _signatures = [
 
 
 @nb.vectorize(_signatures, cache=True)
-def pdf(x, s, loc, scale):
-    """
-    Return probability density of lognormal distribution.
-    """
-    return np.exp(logpdf(x, s, loc, scale))
-
-
-@nb.vectorize(_signatures, cache=True)
 def logpdf(x, s, loc, scale):
     """
     Return log of probability density of lognormal distribution.
@@ -28,6 +20,14 @@ def logpdf(x, s, loc, scale):
     c = np.sqrt(2 * np.pi)
     log_pdf = -0.5 * np.log(z) ** 2 / s ** 2 - np.log(s * z * c)
     return log_pdf - np.log(scale)
+
+
+@nb.vectorize(_signatures, cache=True)
+def pdf(x, s, loc, scale):
+    """
+    Return probability density of lognormal distribution.
+    """
+    return np.exp(logpdf(x, s, loc, scale))
 
 
 @nb.vectorize(_signatures, cache=True)

--- a/src/numba_stats/norm.py
+++ b/src/numba_stats/norm.py
@@ -15,7 +15,7 @@ def _cdf(z):
     return 0.5 * (1.0 + _erf(z * c))
 
 
-@nb.njit
+@nb.njit  # cannot be cached because of call to _erfinv
 def _ppf(p):
     return np.sqrt(2) * _erfinv(2 * p - 1)
 


### PR DESCRIPTION
On first compilation, lognorm.cdf would emit a NumbaWarning and a NumbaDeprecationWarning.

Fixed by simply placing `def logpf()` in front of `def pdf()` in [lognorm.py](https://github.com/HDembinski/numba-stats/blob/main/src/numba_stats/lognorm.py). Closes #33 