### PR TITLE
improve and unify docs, use _vectorized and _jit

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ We provide numba-accelerated implementations of statistical functions for common
 * Student's t
 * Voigtian
 * Crystal Ball
+* Generalised double-sided Crystal Ball
 * Tsallis-Hagedorn, a model for the minimum bias pT distribution
 * Q-Gaussian
 * Bernstein density (not normalised to unity, use this in extended likelihood fits)
@@ -20,7 +21,11 @@ with more to come. The speed gains are huge, up to a factor of 100 compared to `
 
 ## Documentation (or lack of)
 
-Because of limited manpower, this project is poorly documented. The documentation is basically the source code. `pydoc numba_stats` does not really work at the moment, because Numba does not show the docstring of the wrapped function but the docstring of the wrapping function. The plan is to fix this (either in Numba or locally). The calling conventions for those functions which have a `scipy.stats` equivalent, are identical to those in SciPy. These conventions are sometimes a bit unusual, for example, in case of the exponential, the log-normal or the uniform distribution. See the SciPy docs for details.
+Because of a technical limitation of Numba, this project is poorly documented. Functions with equivalents in `scipy.stats` follow the Scipy calling conventions exactly. These conventions are sometimes a bit unusual, for example, in case of the exponential, the log-normal or the uniform distribution. See the SciPy docs for details.
+
+Please look into the source code for documentation of the other functions.
+
+Technical note: `pydoc numba_stats` does not show anything useful, because `numba.vectorize` creates instances of a class `DUFunc`. The wrapped functions show up as objects of that class and `help()` shows the generic documentation of that class instead of the documentation for the instances.
 
 ## Contributions
 

--- a/src/numba_stats/_util.py
+++ b/src/numba_stats/_util.py
@@ -1,0 +1,26 @@
+import numba as nb
+import functools
+from typing import Callable
+
+
+def _vectorize(narg, cache=True, **kwargs):
+    def outer(func):
+
+        signatures = [arg(*([arg] * narg)) for arg in (nb.float32, nb.float64)]
+
+        wrapped = nb.vectorize(signatures, cache=cache, **kwargs)(func)
+        functools.update_wrapper(wrapped, func)
+
+        return wrapped
+
+    return outer
+
+
+def _jit(*args, cache=True, **kwargs):
+    if len(args) == 1 and isinstance(args[0], Callable):
+        return nb.njit(cache=cache, **kwargs)(args[0])
+
+    def outer(func):
+        return nb.njit(cache=cache, **kwargs)(func)
+
+    return outer

--- a/src/numba_stats/_util.py
+++ b/src/numba_stats/_util.py
@@ -5,10 +5,14 @@ from typing import Callable
 
 def _vectorize(narg, cache=True, **kwargs):
     def outer(func):
+        if "cache" not in kwargs:
+            kwargs["cache"] = cache
+        # if "error_model" not in kwargs:
+        #     kwargs["error_model"] = "numpy"
 
         signatures = [arg(*([arg] * narg)) for arg in (nb.float32, nb.float64)]
 
-        wrapped = nb.vectorize(signatures, cache=cache, **kwargs)(func)
+        wrapped = nb.vectorize(signatures, **kwargs)(func)
         # this does not help with the docs, unfortunately
         functools.update_wrapper(wrapped, func)
 
@@ -17,11 +21,14 @@ def _vectorize(narg, cache=True, **kwargs):
     return outer
 
 
-def _jit(*args, cache=True, **kwargs):
+def _jit(*args, **kwargs):
+    if "error_model" not in kwargs:
+        kwargs["error_model"] = "numpy"
+
     if len(args) == 1 and isinstance(args[0], Callable):
-        return nb.njit(cache=cache, **kwargs)(args[0])
+        return nb.njit(**kwargs)(args[0])
 
     def outer(func):
-        return nb.njit(cache=cache, **kwargs)(func)
+        return nb.njit(**kwargs)(func)
 
     return outer

--- a/src/numba_stats/_util.py
+++ b/src/numba_stats/_util.py
@@ -9,6 +9,7 @@ def _vectorize(narg, cache=True, **kwargs):
         signatures = [arg(*([arg] * narg)) for arg in (nb.float32, nb.float64)]
 
         wrapped = nb.vectorize(signatures, cache=cache, **kwargs)(func)
+        # this does not help with the docs, unfortunately
         functools.update_wrapper(wrapped, func)
 
         return wrapped

--- a/src/numba_stats/cpoisson.py
+++ b/src/numba_stats/cpoisson.py
@@ -1,17 +1,11 @@
-import numba as nb
 from ._special import gammaincc as _gammaincc
+from ._util import _vectorize
 
 
-_signatures = [
-    nb.float32(nb.float32, nb.float32),
-    nb.float64(nb.float64, nb.float64),
-]
-
-
-@nb.vectorize(_signatures)
+@_vectorize(2, cache=False)
 def cdf(x, mu):
     """
-    Evaluate cumulative distribution function of continuous Poisson distribution.
+    Return cumulative probability of continuous Poisson distribution.
     """
     return _gammaincc(x + 1, mu)
 

--- a/src/numba_stats/cpoisson.py
+++ b/src/numba_stats/cpoisson.py
@@ -1,3 +1,6 @@
+"""
+Continuous Poisson distribution.
+"""
 from ._special import gammaincc as _gammaincc
 from ._util import _vectorize
 
@@ -5,7 +8,7 @@ from ._util import _vectorize
 @_vectorize(2, cache=False)
 def cdf(x, mu):
     """
-    Return cumulative probability of continuous Poisson distribution.
+    Return cumulative probability.
     """
     return _gammaincc(x + 1, mu)
 

--- a/src/numba_stats/crystalball.py
+++ b/src/numba_stats/crystalball.py
@@ -1,9 +1,9 @@
-import numba as nb
+from ._util import _jit, _vectorize
 import numpy as np
 from math import erf as _erf
 
 
-@nb.njit(cache=True)
+@_jit
 def _powerlaw(z, beta, m):
     assert beta > 0
     assert m > 0
@@ -13,7 +13,7 @@ def _powerlaw(z, beta, m):
     return a * (b - z) ** -m
 
 
-@nb.njit(cache=True)
+@_jit
 def _powerlaw_integral(z, beta, m):
     assert beta > 0
     assert m > 1
@@ -24,26 +24,20 @@ def _powerlaw_integral(z, beta, m):
     return a * (b - z) ** -m1 / m1
 
 
-@nb.njit(cache=True)
+@_jit
 def _normal_integral(a, b):
     sqrt_half = np.sqrt(0.5)
     return sqrt_half * np.sqrt(np.pi) * (_erf(b * sqrt_half) - _erf(a * sqrt_half))
 
 
-@nb.njit(cache=True)
+@_jit
 def _density(z, beta, m):
     if z <= -beta:
         return _powerlaw(z, beta, m)
     return np.exp(-0.5 * z ** 2)
 
 
-_signatures = [
-    nb.float32(nb.float32, nb.float32, nb.float32, nb.float32, nb.float32),
-    nb.float64(nb.float64, nb.float64, nb.float64, nb.float64, nb.float64),
-]
-
-
-@nb.vectorize(_signatures, cache=True)
+@_vectorize(5)
 def pdf(x, beta, m, loc, scale):
     """
     Return probability density of Crystal Ball distribution.
@@ -61,10 +55,10 @@ def pdf(x, beta, m, loc, scale):
     return dens / norm
 
 
-@nb.vectorize(_signatures, cache=True)
+@_vectorize(5)
 def cdf(x, beta, m, loc, scale):
     """
-    Evaluate cumulative distribution function of Crystal Ball distribution.
+    Return cumulative probability of Crystal Ball distribution.
     """
     z = (x - loc) / scale
     norm = _powerlaw_integral(-beta, beta, m) + _normal_integral(-beta, np.inf)

--- a/src/numba_stats/crystalball.py
+++ b/src/numba_stats/crystalball.py
@@ -1,3 +1,12 @@
+"""
+Crystal Ball distribution.
+
+The Crystal Ball distribution replaces the lower tail of a normal distribution with
+a power-law tail.
+
+https://en.wikipedia.org/wiki/Crystal_Ball_function
+"""
+
 from ._util import _jit, _vectorize
 import numpy as np
 from math import erf as _erf
@@ -40,12 +49,7 @@ def _density(z, beta, m):
 @_vectorize(5)
 def pdf(x, beta, m, loc, scale):
     """
-    Return probability density of Crystal Ball distribution.
-
-    The Crystal Ball distribution replaces the lower tail of a normal distribution with
-    a power-law tail.
-
-    https://en.wikipedia.org/wiki/Crystal_Ball_function
+    Return probability density.
     """
     z = (x - loc) / scale
     dens = _density(z, beta, m)
@@ -58,7 +62,7 @@ def pdf(x, beta, m, loc, scale):
 @_vectorize(5)
 def cdf(x, beta, m, loc, scale):
     """
-    Return cumulative probability of Crystal Ball distribution.
+    Return cumulative probability.
     """
     z = (x - loc) / scale
     norm = _powerlaw_integral(-beta, beta, m) + _normal_integral(-beta, np.inf)

--- a/src/numba_stats/crystalball_ex.py
+++ b/src/numba_stats/crystalball_ex.py
@@ -1,37 +1,13 @@
 from .crystalball import _powerlaw_integral, _normal_integral, _density
-import numba as nb
+from ._util import _vectorize, _jit
 
 
-@nb.njit
+@_jit
 def _norm_half(beta, m, scale):
     return (_normal_integral(0, beta) + _powerlaw_integral(-beta, beta, m)) * scale
 
 
-_signatures = [
-    nb.float32(
-        nb.float32,
-        nb.float32,
-        nb.float32,
-        nb.float32,
-        nb.float32,
-        nb.float32,
-        nb.float32,
-        nb.float32,
-    ),
-    nb.float64(
-        nb.float64,
-        nb.float64,
-        nb.float64,
-        nb.float64,
-        nb.float64,
-        nb.float64,
-        nb.float64,
-        nb.float64,
-    ),
-]
-
-
-@nb.vectorize(_signatures, cache=True)
+@_vectorize(8)
 def pdf(x, beta_left, m_left, scale_left, beta_right, m_right, scale_right, loc):
     """
     Return probability density of generalised Crystal Ball distribution.
@@ -58,10 +34,10 @@ def pdf(x, beta_left, m_left, scale_left, beta_right, m_right, scale_right, loc)
     )
 
 
-@nb.vectorize(_signatures, cache=True)
+@_vectorize(8)
 def cdf(x, beta_left, m_left, scale_left, beta_right, m_right, scale_right, loc):
     """
-    Return probability density of generalised Crystal Ball distribution.
+    Return cumulative probability of generalised Crystal Ball distribution.
     """
     norm = _norm_half(beta_left, m_left, scale_left) + _norm_half(
         beta_right, m_right, scale_right

--- a/src/numba_stats/crystalball_ex.py
+++ b/src/numba_stats/crystalball_ex.py
@@ -1,3 +1,12 @@
+"""
+Generalised Crystal Ball distribution.
+
+The generalised Crystal Ball distribution replaces the lower and upper tail of
+an asymmetric normal distribution with power-law tails. Furthermore, the scale
+is allowed to vary between the left and the right side of the peak. There is no
+discontinuity at the maximum or elsewhere.
+"""
+
 from .crystalball import _powerlaw_integral, _normal_integral, _density
 from ._util import _vectorize, _jit
 
@@ -10,12 +19,7 @@ def _norm_half(beta, m, scale):
 @_vectorize(8)
 def pdf(x, beta_left, m_left, scale_left, beta_right, m_right, scale_right, loc):
     """
-    Return probability density of generalised Crystal Ball distribution.
-
-    The generalised Crystal Ball distribution replaces the lower and upper tail of
-    an asymmetric normal distribution with power-law tails. Furthermore, the scale
-    is allowed to vary between the left and the right side of the peak. There is no
-    discontinuity at the maximum or elsewhere.
+    Return probability density.
     """
     if x < loc:
         scale = scale_left
@@ -37,7 +41,7 @@ def pdf(x, beta_left, m_left, scale_left, beta_right, m_right, scale_right, loc)
 @_vectorize(8)
 def cdf(x, beta_left, m_left, scale_left, beta_right, m_right, scale_right, loc):
     """
-    Return cumulative probability of generalised Crystal Ball distribution.
+    Return cumulative probability.
     """
     norm = _norm_half(beta_left, m_left, scale_left) + _norm_half(
         beta_right, m_right, scale_right

--- a/src/numba_stats/expon.py
+++ b/src/numba_stats/expon.py
@@ -1,3 +1,6 @@
+"""
+Exponential distribution.
+"""
 import numpy as np
 from math import expm1 as _expm1, log1p as _log1p
 from ._util import _jit, _vectorize
@@ -22,7 +25,7 @@ def _logpdf(x, loc, scale):
 @_vectorize(3)
 def logpdf(x, loc, scale):
     """
-    Return log of probability density of exponential distribution.
+    Return log of probability density.
     """
     return _logpdf(x, loc, scale)
 
@@ -30,7 +33,7 @@ def logpdf(x, loc, scale):
 @_vectorize(3)
 def pdf(x, loc, scale):
     """
-    Return probability density of exponential distribution.
+    Return probability density.
     """
     return np.exp(_logpdf(x, loc, scale))
 
@@ -38,7 +41,7 @@ def pdf(x, loc, scale):
 @_vectorize(3)
 def cdf(x, loc, scale):
     """
-    Return cumulative probability of exponential distribution.
+    Return cumulative probability.
     """
     z = (x - loc) / scale
     return _cdf(z)
@@ -47,7 +50,7 @@ def cdf(x, loc, scale):
 @_vectorize(3)
 def ppf(p, loc, scale):
     """
-    Return quantile of exponential distribution for given probability.
+    Return quantile for given probability.
     """
     z = _ppf(p)
     x = z * scale + loc

--- a/src/numba_stats/expon.py
+++ b/src/numba_stats/expon.py
@@ -1,36 +1,54 @@
-import numba as nb
 import numpy as np
 from math import expm1 as _expm1, log1p as _log1p
-
-_signatures = [
-    nb.float32(nb.float32, nb.float32, nb.float32),
-    nb.float64(nb.float64, nb.float64, nb.float64),
-]
+from ._util import _jit, _vectorize
 
 
-@nb.vectorize(_signatures, cache=True)
-def pdf(x, mu, sigma):
-    """
-    Return probability density of exponential distribution.
-    """
-    z = (x - mu) / sigma
-    return np.exp(-z) / sigma
-
-
-@nb.vectorize(_signatures, cache=True)
-def cdf(x, mu, sigma):
-    """
-    Evaluate cumulative distribution function of exponential distribution.
-    """
-    z = (x - mu) / sigma
+@_jit
+def _cdf(z):
     return -_expm1(-z)
 
 
-@nb.vectorize(_signatures, cache=True)
-def ppf(p, mu, sigma):
+@_jit
+def _ppf(p):
+    return -_log1p(-p)
+
+
+@_jit
+def _logpdf(x, loc, scale):
+    z = (x - loc) / scale
+    return -z - np.log(scale)
+
+
+@_vectorize(3)
+def logpdf(x, loc, scale):
+    """
+    Return log of probability density of exponential distribution.
+    """
+    return _logpdf(x, loc, scale)
+
+
+@_vectorize(3)
+def pdf(x, loc, scale):
+    """
+    Return probability density of exponential distribution.
+    """
+    return np.exp(_logpdf(x, loc, scale))
+
+
+@_vectorize(3)
+def cdf(x, loc, scale):
+    """
+    Return cumulative probability of exponential distribution.
+    """
+    z = (x - loc) / scale
+    return _cdf(z)
+
+
+@_vectorize(3)
+def ppf(p, loc, scale):
     """
     Return quantile of exponential distribution for given probability.
     """
-    z = -_log1p(-p)
-    x = z * sigma + mu
+    z = _ppf(p)
+    x = z * scale + loc
     return x

--- a/src/numba_stats/lognorm.py
+++ b/src/numba_stats/lognorm.py
@@ -1,8 +1,12 @@
+"""
+Lognormal distribution.
+"""
 import numpy as np
 from .norm import _cdf, _ppf
 from ._util import _jit, _vectorize
 
 
+# has to be separate to avoid a warning
 @_jit
 def _logpdf(x, s, loc, scale):
     z = (x - loc) / scale
@@ -16,7 +20,7 @@ def _logpdf(x, s, loc, scale):
 @_vectorize(4)
 def logpdf(x, s, loc, scale):
     """
-    Return log of probability density of lognormal distribution.
+    Return log of probability density.
     """
     return _logpdf(x, s, loc, scale)
 
@@ -24,7 +28,7 @@ def logpdf(x, s, loc, scale):
 @_vectorize(4)
 def pdf(x, s, loc, scale):
     """
-    Return probability density of lognormal distribution.
+    Return probability density.
     """
     return np.exp(_logpdf(x, s, loc, scale))
 
@@ -32,7 +36,7 @@ def pdf(x, s, loc, scale):
 @_vectorize(4)
 def cdf(x, s, loc, scale):
     """
-    Return cumulative probability of lognormal distribution.
+    Return cumulative probability.
     """
     z = (x - loc) / scale
     if z <= 0:
@@ -43,7 +47,7 @@ def cdf(x, s, loc, scale):
 @_vectorize(4, cache=False)  # no cache because of _ppf
 def ppf(p, s, loc, scale):
     """
-    Return quantile of lognormal distribution for given probability.
+    Return quantile for given probability.
     """
     z = np.exp(s * _ppf(p))
     return scale * z + loc

--- a/src/numba_stats/lognorm.py
+++ b/src/numba_stats/lognorm.py
@@ -1,9 +1,9 @@
-import numba as nb
 import numpy as np
 from .norm import _cdf, _ppf
+from ._util import _jit, _vectorize
 
 
-@nb.njit(cache=True)
+@_jit
 def _logpdf(x, s, loc, scale):
     z = (x - loc) / scale
     if z <= 0:
@@ -13,13 +13,7 @@ def _logpdf(x, s, loc, scale):
     return log_pdf - np.log(scale)
 
 
-_signatures = [
-    nb.float32(nb.float32, nb.float32, nb.float32, nb.float32),
-    nb.float64(nb.float64, nb.float64, nb.float64, nb.float64),
-]
-
-
-@nb.vectorize(_signatures, cache=True)
+@_vectorize(4)
 def logpdf(x, s, loc, scale):
     """
     Return log of probability density of lognormal distribution.
@@ -27,7 +21,7 @@ def logpdf(x, s, loc, scale):
     return _logpdf(x, s, loc, scale)
 
 
-@nb.vectorize(_signatures, cache=True)
+@_vectorize(4)
 def pdf(x, s, loc, scale):
     """
     Return probability density of lognormal distribution.
@@ -35,10 +29,10 @@ def pdf(x, s, loc, scale):
     return np.exp(_logpdf(x, s, loc, scale))
 
 
-@nb.vectorize(_signatures, cache=True)
+@_vectorize(4)
 def cdf(x, s, loc, scale):
     """
-    Evaluate cumulative distribution function of lognormal distribution.
+    Return cumulative probability of lognormal distribution.
     """
     z = (x - loc) / scale
     if z <= 0:
@@ -46,7 +40,7 @@ def cdf(x, s, loc, scale):
     return _cdf(np.log(z) / s)
 
 
-@nb.vectorize(_signatures)  # cannot be cached because of call to _ppf
+@_vectorize(4, cache=False)  # no cache because of _ppf
 def ppf(p, s, loc, scale):
     """
     Return quantile of lognormal distribution for given probability.

--- a/src/numba_stats/norm.py
+++ b/src/numba_stats/norm.py
@@ -1,64 +1,58 @@
-import numba as nb
 import numpy as np
 from ._special import erfinv as _erfinv
+from ._util import _vectorize, _jit
 from math import erf as _erf
 
 
-@nb.njit(cache=True)
+@_jit
 def _logpdf(z):
     return -0.5 * (z ** 2 + np.log(2 * np.pi))
 
 
-@nb.njit(cache=True)
+@_jit
 def _cdf(z):
     c = np.sqrt(0.5)
     return 0.5 * (1.0 + _erf(z * c))
 
 
-@nb.njit  # cannot be cached because of call to _erfinv
+@_jit(cache=False)  # cannot cache because of _erfinv
 def _ppf(p):
     return np.sqrt(2) * _erfinv(2 * p - 1)
 
 
-_signatures = [
-    nb.float32(nb.float32, nb.float32, nb.float32),
-    nb.float64(nb.float64, nb.float64, nb.float64),
-]
-
-
-@nb.vectorize(_signatures, cache=True)
-def logpdf(x, mu, sigma):
+@_vectorize(3)
+def logpdf(x, loc, scale):
     """
     Return log of probability density of normal distribution.
     """
-    z = (x - mu) / sigma
-    return _logpdf(z) - np.log(sigma)
+    z = (x - loc) / scale
+    return _logpdf(z) - np.log(scale)
 
 
-@nb.vectorize(_signatures, cache=True)
-def pdf(x, mu, sigma):
+@_vectorize(3)
+def pdf(x, loc, scale):
     """
     Return probability density of normal distribution.
     """
     # cannot call logpdf directly here, because nb.vectorize does not generate
     # inlinable code
-    z = (x - mu) / sigma
-    return np.exp(_logpdf(z)) / sigma
+    z = (x - loc) / scale
+    return np.exp(_logpdf(z)) / scale
 
 
-@nb.vectorize(_signatures, cache=True)
-def cdf(x, mu, sigma):
+@_vectorize(3)
+def cdf(x, loc, scale):
     """
-    Evaluate cumulative distribution function of normal distribution.
+    Return cumulative probability of normal distribution.
     """
-    z = (x - mu) / sigma
+    z = (x - loc) / scale
     return _cdf(z)
 
 
-@nb.vectorize(_signatures)
-def ppf(p, mu, sigma):
+@_vectorize(3, cache=False)  # cannot cache this
+def ppf(p, loc, scale):
     """
     Return quantile of normal distribution for given probability.
     """
     z = _ppf(p)
-    return sigma * z + mu
+    return scale * z + loc

--- a/src/numba_stats/norm.py
+++ b/src/numba_stats/norm.py
@@ -1,3 +1,6 @@
+"""
+Normal distribution.
+"""
 import numpy as np
 from ._special import erfinv as _erfinv
 from ._util import _vectorize, _jit
@@ -34,10 +37,7 @@ def pdf(x, loc, scale):
     """
     Return probability density of normal distribution.
     """
-    # cannot call logpdf directly here, because nb.vectorize does not generate
-    # inlinable code
-    z = (x - loc) / scale
-    return np.exp(_logpdf(z)) / scale
+    return np.exp(logpdf(x, loc, scale))
 
 
 @_vectorize(3)

--- a/src/numba_stats/poisson.py
+++ b/src/numba_stats/poisson.py
@@ -10,14 +10,21 @@ _signatures = [
 
 
 @nb.vectorize(_signatures)
+def logpmf(k, mu):
+    """
+    Return log of probability mass for Poisson distribution.
+    """
+    if mu == 0:
+        return 0.0 if k == 0 else -np.inf
+    return k * np.log(mu) - _lgamma(k + 1.0) - mu
+
+
+@nb.vectorize(_signatures)
 def pmf(k, mu):
     """
     Return probability mass for Poisson distribution.
     """
-    if mu == 0:
-        return 1.0 if k == 0 else 0.0
-    logp = k * np.log(mu) - _lgamma(k + 1.0) - mu
-    return np.exp(logp)
+    return np.exp(logpmf(k, mu))
 
 
 @nb.vectorize(_signatures)

--- a/src/numba_stats/t.py
+++ b/src/numba_stats/t.py
@@ -1,37 +1,32 @@
-import numba as nb
 import numpy as np
 from ._special import stdtr as _cdf, stdtrit as _ppf
+from ._util import _vectorize
 from math import lgamma as _lgamma
 
-_signatures = [
-    nb.float32(nb.float32, nb.float32, nb.float32, nb.float32),
-    nb.float64(nb.float64, nb.float64, nb.float64, nb.float64),
-]
 
-
-@nb.vectorize(_signatures, cache=True)
-def pdf(x, df, mu, sigma):
+@_vectorize(4, cache=False)
+def pdf(x, df, loc, scale):
     """
     Return probability density of student's distribution.
     """
-    z = (x - mu) / sigma
+    z = (x - loc) / scale
     k = 0.5 * (df + 1)
     p = np.exp(_lgamma(k) - _lgamma(0.5 * df))
     p /= np.sqrt(df * np.pi) * (1 + (z ** 2) / df) ** k
-    return p / sigma
+    return p / scale
 
 
-@nb.vectorize(_signatures)
-def cdf(x, df, mu, sigma):
+@_vectorize(4, cache=False)
+def cdf(x, df, loc, scale):
     """
-    Evaluate cumulative distribution function of student's distribution.
+    Return cumulative probability of student's distribution.
     """
-    z = (x - mu) / sigma
+    z = (x - loc) / scale
     return _cdf(df, z)
 
 
-@nb.vectorize(_signatures)
-def ppf(p, df, mu, sigma):
+@_vectorize(4, cache=False)
+def ppf(p, df, loc, scale):
     """
     Return quantile of student's distribution for given probability.
     """
@@ -40,4 +35,4 @@ def ppf(p, df, mu, sigma):
     elif p == 1:
         return np.inf
     z = _ppf(df, p)
-    return sigma * z + mu
+    return scale * z + loc

--- a/src/numba_stats/t.py
+++ b/src/numba_stats/t.py
@@ -5,15 +5,23 @@ from math import lgamma as _lgamma
 
 
 @_vectorize(4, cache=False)
-def pdf(x, df, loc, scale):
+def logpdf(x, df, loc, scale):
     """
     Return probability density of student's distribution.
     """
     z = (x - loc) / scale
     k = 0.5 * (df + 1)
-    p = np.exp(_lgamma(k) - _lgamma(0.5 * df))
-    p /= np.sqrt(df * np.pi) * (1 + (z ** 2) / df) ** k
-    return p / scale
+    logp = _lgamma(k) - _lgamma(0.5 * df)
+    logp -= 0.5 * np.log(df * np.pi) + k * np.log(1 + (z ** 2) / df) + np.log(scale)
+    return logp
+
+
+@_vectorize(4, cache=False)
+def pdf(x, df, loc, scale):
+    """
+    Return probability density of student's distribution.
+    """
+    return np.exp(logpdf(x, df, loc, scale))
 
 
 @_vectorize(4, cache=False)

--- a/src/numba_stats/truncexpon.py
+++ b/src/numba_stats/truncexpon.py
@@ -4,19 +4,27 @@ from .expon import _cdf, _ppf
 
 
 @_vectorize(5)
-def pdf(x, xmin, xmax, loc, scale):
+def logpdf(x, xmin, xmax, loc, scale):
     """
-    Return probability density of exponential distribution.
+    Return log of probability density of truncated exponential distribution.
     """
     if x < xmin:
-        return 0.0
+        return -np.inf
     elif x > xmax:
-        return 0.0
+        return -np.inf
     scale_inv = 1 / scale
     z = (x - loc) * scale_inv
     zmin = (xmin - loc) * scale_inv
     zmax = (xmax - loc) * scale_inv
-    return np.exp(-z) * scale_inv / (_cdf(zmax) - _cdf(zmin))
+    return -z + np.log(scale_inv / (_cdf(zmax) - _cdf(zmin)))
+
+
+@_vectorize(5)
+def pdf(x, xmin, xmax, loc, scale):
+    """
+    Return probability density of truncated exponential distribution.
+    """
+    return np.exp(logpdf(x, xmin, xmax, loc, scale))
 
 
 @_vectorize(5)
@@ -41,7 +49,7 @@ def cdf(x, xmin, xmax, loc, scale):
 @_vectorize(5)
 def ppf(p, xmin, xmax, loc, scale):
     """
-    Return quantile of exponential distribution for given probability.
+    Return quantile of truncated exponential distribution for given probability.
     """
     scale_inv = 1 / scale
     zmin = (xmin - loc) * scale_inv

--- a/src/numba_stats/truncexpon.py
+++ b/src/numba_stats/truncexpon.py
@@ -1,20 +1,10 @@
-import numba as nb
 import numpy as np
-from math import expm1 as _expm1, log1p as _log1p
-
-_signatures = [
-    nb.float32(nb.float32, nb.float32, nb.float32, nb.float32, nb.float32),
-    nb.float64(nb.float64, nb.float64, nb.float64, nb.float64, nb.float64),
-]
+from ._util import _vectorize
+from .expon import _cdf, _ppf
 
 
-@nb.njit
-def _cdf(z):
-    return -_expm1(-z)
-
-
-@nb.vectorize(_signatures, cache=True)
-def pdf(x, xmin, xmax, mu, sigma):
+@_vectorize(5)
+def pdf(x, xmin, xmax, loc, scale):
     """
     Return probability density of exponential distribution.
     """
@@ -22,43 +12,43 @@ def pdf(x, xmin, xmax, mu, sigma):
         return 0.0
     elif x > xmax:
         return 0.0
-    sigma_inv = 1 / sigma
-    z = (x - mu) * sigma_inv
-    zmin = (xmin - mu) * sigma_inv
-    zmax = (xmax - mu) * sigma_inv
-    return np.exp(-z) * sigma_inv / (_cdf(zmax) - _cdf(zmin))
+    scale_inv = 1 / scale
+    z = (x - loc) * scale_inv
+    zmin = (xmin - loc) * scale_inv
+    zmax = (xmax - loc) * scale_inv
+    return np.exp(-z) * scale_inv / (_cdf(zmax) - _cdf(zmin))
 
 
-@nb.vectorize(_signatures, cache=True)
-def cdf(x, xmin, xmax, mu, sigma):
+@_vectorize(5)
+def cdf(x, xmin, xmax, loc, scale):
     """
-    Evaluate cumulative distribution function of exponential distribution.
+    Return cumulative probability of truncated exponential distribution.
     """
     if x < xmin:
         return 0.0
     elif x > xmax:
         return 1.0
-    sigma_inv = 1 / sigma
-    z = (x - mu) * sigma_inv
+    scale_inv = 1 / scale
+    z = (x - loc) * scale_inv
     p = _cdf(z)
-    zmin = (xmin - mu) * sigma_inv
-    zmax = (xmax - mu) * sigma_inv
+    zmin = (xmin - loc) * scale_inv
+    zmax = (xmax - loc) * scale_inv
     pmin = _cdf(zmin)
     pmax = _cdf(zmax)
     return (p - pmin) / (pmax - pmin)
 
 
-@nb.vectorize(_signatures, cache=True)
-def ppf(p, xmin, xmax, mu, sigma):
+@_vectorize(5)
+def ppf(p, xmin, xmax, loc, scale):
     """
     Return quantile of exponential distribution for given probability.
     """
-    sigma_inv = 1 / sigma
-    zmin = (xmin - mu) * sigma_inv
-    zmax = (xmax - mu) * sigma_inv
+    scale_inv = 1 / scale
+    zmin = (xmin - loc) * scale_inv
+    zmax = (xmax - loc) * scale_inv
     pmin = _cdf(zmin)
     pmax = _cdf(zmax)
     pstar = p * (pmax - pmin) + pmin
-    z = -_log1p(-pstar)
-    x = z * sigma + mu
+    z = _ppf(pstar)
+    x = z * scale + loc
     return x

--- a/src/numba_stats/truncnorm.py
+++ b/src/numba_stats/truncnorm.py
@@ -1,3 +1,7 @@
+"""
+Truncated normal distribution.
+"""
+
 import numpy as np
 from .norm import _logpdf as _norm_logpdf, _cdf, _ppf
 from ._util import _jit, _vectorize
@@ -13,7 +17,7 @@ def _logpdf(z, zmin, zmax):
 @_vectorize(5)
 def logpdf(x, xmin, xmax, loc, scale):
     """
-    Return log of probability density of normal distribution.
+    Return log of probability density.
     """
     scale_inv = 1 / scale
     z = (x - loc) * scale_inv
@@ -25,7 +29,7 @@ def logpdf(x, xmin, xmax, loc, scale):
 @_vectorize(5)
 def pdf(x, xmin, xmax, loc, scale):
     """
-    Return probability density of truncated normal distribution.
+    Return probability density.
     """
     scale_inv = 1 / scale
     z = (x - loc) * scale_inv
@@ -37,7 +41,7 @@ def pdf(x, xmin, xmax, loc, scale):
 @_vectorize(5)
 def cdf(x, xmin, xmax, loc, scale):
     """
-    Return cumulative probability of truncated normal distribution.
+    Return cumulative probability.
     """
     if x < xmin:
         return 0.0
@@ -55,7 +59,7 @@ def cdf(x, xmin, xmax, loc, scale):
 @_vectorize(5, cache=False)
 def ppf(p, xmin, xmax, loc, scale):
     """
-    Return quantile of truncated normal distribution for given probability.
+    Return quantile for given probability.
     """
     scale_inv = 1 / scale
     zmin = (xmin - loc) * scale_inv

--- a/src/numba_stats/truncnorm.py
+++ b/src/numba_stats/truncnorm.py
@@ -1,72 +1,67 @@
-import numba as nb
 import numpy as np
 from .norm import _logpdf as _norm_logpdf, _cdf, _ppf
-
-_signatures = [
-    nb.float32(nb.float32, nb.float32, nb.float32, nb.float32, nb.float32),
-    nb.float64(nb.float64, nb.float64, nb.float64, nb.float64, nb.float64),
-]
+from ._util import _jit, _vectorize
 
 
-@nb.njit(cache=True)
+@_jit
 def _logpdf(z, zmin, zmax):
     if z < zmin or z > zmax:
         return -np.inf
     return _norm_logpdf(z) - np.log(_cdf(zmax) - _cdf(zmin))
 
 
-@nb.vectorize(_signatures, cache=True)
-def logpdf(x, xmin, xmax, mu, sigma):
+@_vectorize(5)
+def logpdf(x, xmin, xmax, loc, scale):
     """
     Return log of probability density of normal distribution.
     """
-    sigma_inv = 1 / sigma
-    z = (x - mu) * sigma_inv
-    zmin = (xmin - mu) * sigma_inv
-    zmax = (xmax - mu) * sigma_inv
-    return _logpdf(z, zmin, zmax) + np.log(sigma_inv)
+    scale_inv = 1 / scale
+    z = (x - loc) * scale_inv
+    zmin = (xmin - loc) * scale_inv
+    zmax = (xmax - loc) * scale_inv
+    return _logpdf(z, zmin, zmax) + np.log(scale_inv)
 
 
-@nb.vectorize(_signatures, cache=True)
-def pdf(x, xmin, xmax, mu, sigma):
+@_vectorize(5)
+def pdf(x, xmin, xmax, loc, scale):
     """
-    Return probability density of normal distribution.
+    Return probability density of truncated normal distribution.
     """
-    sigma_inv = 1 / sigma
-    z = (x - mu) * sigma_inv
-    zmin = (xmin - mu) * sigma_inv
-    zmax = (xmax - mu) * sigma_inv
-    return np.exp(_logpdf(z, zmin, zmax)) * sigma_inv
+    scale_inv = 1 / scale
+    z = (x - loc) * scale_inv
+    zmin = (xmin - loc) * scale_inv
+    zmax = (xmax - loc) * scale_inv
+    return np.exp(_logpdf(z, zmin, zmax)) * scale_inv
 
 
-@nb.vectorize(_signatures, cache=True)
-def cdf(x, xmin, xmax, mu, sigma):
+@_vectorize(5)
+def cdf(x, xmin, xmax, loc, scale):
     """
-    Evaluate cumulative distribution function of normal distribution.
+    Return cumulative probability of truncated normal distribution.
     """
     if x < xmin:
         return 0.0
     elif x > xmax:
         return 1.0
-    sigma_inv = 1 / sigma
-    z = (x - mu) * sigma_inv
-    zmin = (xmin - mu) * sigma_inv
-    zmax = (xmax - mu) * sigma_inv
+    scale_inv = 1 / scale
+    z = (x - loc) * scale_inv
+    zmin = (xmin - loc) * scale_inv
+    zmax = (xmax - loc) * scale_inv
     pmin = _cdf(zmin)
     pmax = _cdf(zmax)
     return (_cdf(z) - pmin) / (pmax - pmin)
 
 
-@nb.vectorize(_signatures)
-def ppf(p, xmin, xmax, mu, sigma):
+@_vectorize(5, cache=False)
+def ppf(p, xmin, xmax, loc, scale):
     """
-    Return quantile of normal distribution for given probability.
+    Return quantile of truncated normal distribution for given probability.
     """
-    sigma_inv = 1 / sigma
-    zmin = (xmin - mu) * sigma_inv
-    zmax = (xmax - mu) * sigma_inv
+    scale_inv = 1 / scale
+    zmin = (xmin - loc) * scale_inv
+    zmax = (xmax - loc) * scale_inv
     pmin = _cdf(zmin)
     pmax = _cdf(zmax)
     pstar = p * (pmax - pmin) + pmin
     z = _ppf(pstar)
-    return sigma * z + mu
+    return scale * z + loc

--- a/src/numba_stats/tsallis.py
+++ b/src/numba_stats/tsallis.py
@@ -4,8 +4,12 @@ from ._util import _vectorize
 
 @_vectorize(4)
 def pdf(x, m, t, n):
+    """
+    Return probability density.
+    """
     # Formula from CMS, Eur. Phys. J. C (2012) 72:2164
-    assert n > 2
+    if n <= 2:
+        raise ValueError("n > 2 is required")
 
     mt = np.sqrt(m ** 2 + x ** 2)
     nt = n * t
@@ -16,10 +20,11 @@ def pdf(x, m, t, n):
 @_vectorize(4)
 def cdf(x, m, t, n):
     """
-    Return cumulative probability of Tsallis distribution.
+    Return cumulative probability.
     """
     # Formula computed from tsallis_pdf with Sympy, then simplified by hand
-    assert n > 2
+    if n <= 2:
+        raise ValueError("n > 2 is required")
 
     mt = np.sqrt(m ** 2 + x ** 2)
     nt = n * t

--- a/src/numba_stats/tsallis.py
+++ b/src/numba_stats/tsallis.py
@@ -1,13 +1,8 @@
-import numba as nb
 import numpy as np
-
-_signatures = [
-    nb.float32(nb.float32, nb.float32, nb.float32, nb.float32),
-    nb.float64(nb.float64, nb.float64, nb.float64, nb.float64),
-]
+from ._util import _vectorize
 
 
-@nb.vectorize(_signatures, cache=True)
+@_vectorize(4)
 def pdf(x, m, t, n):
     # Formula from CMS, Eur. Phys. J. C (2012) 72:2164
     assert n > 2
@@ -18,8 +13,11 @@ def pdf(x, m, t, n):
     return c * x * (1 + (mt - m) / nt) ** -n
 
 
-@nb.vectorize(_signatures, cache=True)
+@_vectorize(4)
 def cdf(x, m, t, n):
+    """
+    Return cumulative probability of Tsallis distribution.
+    """
     # Formula computed from tsallis_pdf with Sympy, then simplified by hand
     assert n > 2
 

--- a/src/numba_stats/uniform.py
+++ b/src/numba_stats/uniform.py
@@ -1,20 +1,32 @@
+"""
+Uniform distribution.
+"""
 from ._util import _vectorize
+import numpy as np
+
+
+@_vectorize(3)
+def logpdf(x, a, w):
+    """
+    Return probability density.
+    """
+    if a <= x <= a + w:
+        return -np.log(w)
+    return -np.inf
 
 
 @_vectorize(3)
 def pdf(x, a, w):
     """
-    Return probability density of uniform distribution.
+    Return probability density.
     """
-    if a <= x <= a + w:
-        return 1 / w
-    return 0
+    return np.exp(logpdf(x, a, w))
 
 
 @_vectorize(3)
 def cdf(x, a, w):
     """
-    Return cumulative probability of uniform distribution.
+    Return cumulative probability.
     """
     if a <= x:
         if x <= a + w:
@@ -26,6 +38,6 @@ def cdf(x, a, w):
 @_vectorize(3)
 def ppf(p, a, w):
     """
-    Return quantile of uniform distribution for given probability.
+    Return quantile for given probability.
     """
     return w * p + a

--- a/src/numba_stats/uniform.py
+++ b/src/numba_stats/uniform.py
@@ -1,20 +1,21 @@
-import numba as nb
-
-_signatures = [
-    nb.float32(nb.float32, nb.float32, nb.float32),
-    nb.float64(nb.float64, nb.float64, nb.float64),
-]
+from ._util import _vectorize
 
 
-@nb.vectorize(_signatures, cache=True)
+@_vectorize(3)
 def pdf(x, a, w):
+    """
+    Return probability density of uniform distribution.
+    """
     if a <= x <= a + w:
         return 1 / w
     return 0
 
 
-@nb.vectorize(_signatures, cache=True)
+@_vectorize(3)
 def cdf(x, a, w):
+    """
+    Return cumulative probability of uniform distribution.
+    """
     if a <= x:
         if x <= a + w:
             return (x - a) / w
@@ -22,6 +23,9 @@ def cdf(x, a, w):
     return 0
 
 
-@nb.vectorize(_signatures, cache=True)
+@_vectorize(3)
 def ppf(p, a, w):
+    """
+    Return quantile of uniform distribution for given probability.
+    """
     return w * p + a

--- a/src/numba_stats/voigt.py
+++ b/src/numba_stats/voigt.py
@@ -1,15 +1,10 @@
-import numba as nb
 from ._special import voigt_profile as _voigt
-
-_signatures = [
-    nb.float32(nb.float32, nb.float32, nb.float32, nb.float32),
-    nb.float64(nb.float64, nb.float64, nb.float64, nb.float64),
-]
+from ._util import _vectorize
 
 
-@nb.vectorize(_signatures)
-def pdf(x, gamma, mu, sigma):
+@_vectorize(4, cache=False)
+def pdf(x, gamma, loc, scale):
     """
     Return probability density of Voigtian distribution.
     """
-    return _voigt(x - mu, sigma, gamma)
+    return _voigt(x - loc, scale, gamma)


### PR DESCRIPTION
Unify doc strings, which unfortunately cannot be displayed. Functions wrapped with numba.vectorize are instances of classes, so when you call `help()` on them, the documentation of the class is shown and not the documentation of the wrapped function. There is currently no known way to fix this.

Add `_vectorized` and `_jit` which use the right defaults.