### PR TITLE
Potentially support parallelization

### DIFF
--- a/benchmarks/test_stats.py
+++ b/benchmarks/test_stats.py
@@ -122,3 +122,20 @@ def test_t_ppf_speed(benchmark, which, n):
     m = np.linspace(-1, 1, n)
     s = np.linspace(0.1, 1, n)
     benchmark(lambda: sc.t.ppf(x, df, m, s) if which == "scipy" else t.ppf(x, df, m, s))
+
+
+@pytest.mark.benchmark(group="bernstein.density")
+@pytest.mark.parametrize("which", ("scipy", "ours"))
+@pytest.mark.parametrize("n", (10, 100, 1000, 10000))
+def test_bernstein_density_speed(benchmark, which, n):
+    from numba_stats import bernstein
+    from scipy.interpolate import BPoly
+
+    x = np.linspace(0, 1, n)
+    beta = np.arange(1, 4, dtype=float)
+
+    benchmark(
+        lambda: BPoly(np.array(beta)[:, np.newaxis], [x[0], x[-1]])(x)
+        if which == "scipy"
+        else bernstein.density(x, beta, x[0], x[-1])
+    )

--- a/src/numba_stats/_util.py
+++ b/src/numba_stats/_util.py
@@ -3,6 +3,7 @@ import numpy as np
 from numba.types import Array
 from numba.core.errors import TypingError
 from numba.extending import overload
+from numba import prange as _prange  # noqa
 
 _Floats = (nb.float32, nb.float64)
 

--- a/src/numba_stats/_util.py
+++ b/src/numba_stats/_util.py
@@ -14,7 +14,7 @@ def _readonly_carray(T):
 
 def _jit(arg, cache=True):
     if isinstance(arg, list):
-        return nb.njit(arg, cache=cache, error_model="numpy")
+        return nb.njit(arg, cache=cache, inline="always", error_model="numpy")
 
     signatures = []
     for T in (nb.float32, nb.float64):
@@ -24,7 +24,7 @@ def _jit(arg, cache=True):
             sig = T[:](_readonly_carray(T), *[T for _ in range(arg)])
         signatures.append(sig)
 
-    return nb.njit(signatures, cache=cache, error_model="numpy")
+    return nb.njit(signatures, cache=cache, inline="always", error_model="numpy")
 
 
 def _wrap(fn):
@@ -80,11 +80,12 @@ def _generate_wrappers(d):
             "cdf": "Return cumulative probability.",
             "ppf": "Return quantile for given probability.",
         }.get(fname, None)
+
         code = f"""
 def {fname}({args}):
     return _wrap({impl})({args})
 
-@_overload({fname})
+@_overload({fname}, inline="always")
 def _ol_{fname}({args}):
     _type_check({args})
     return {impl}.__wrapped__

--- a/src/numba_stats/bernstein.py
+++ b/src/numba_stats/bernstein.py
@@ -17,7 +17,7 @@ scipy.interpolate.BPoly: Bernstein polynomials in Scipy.
 """
 
 import numpy as np
-from ._util import _jit, _Floats, _generate_wrappers, _readonly_carray, _trans
+from ._util import _jit, _Floats, _generate_wrappers, _readonly_carray, _trans, _prange
 
 
 @_jit([T[:](_readonly_carray(T), _readonly_carray(T)) for T in _Floats])
@@ -25,17 +25,16 @@ def _de_castlejau(z, beta):
     # De Casteljau algorithm, numerically stable
     n = len(beta)
     res = np.empty_like(z)
-    if n == 0:
-        res[:] = np.nan
-    else:
-        betai = np.empty_like(beta)
-        for i, zi in enumerate(z):
-            azi = 1.0 - zi
-            betai[:] = beta
+    if n > 0:
+        for i in _prange(len(z)):
+            azi = 1.0 - z[i]
+            betai = beta.copy()
             for j in range(1, n):
                 for k in range(n - j):
-                    betai[k] = betai[k] * azi + betai[k + 1] * zi
+                    betai[k] = betai[k] * azi + betai[k + 1] * z[i]
             res[i] = betai[0]
+    else:
+        res[:] = np.nan
     return res
 
 

--- a/src/numba_stats/cpoisson.py
+++ b/src/numba_stats/cpoisson.py
@@ -17,7 +17,7 @@ https://en.wikipedia.org/wiki/Incomplete_gamma_function#Derivatives
 There is a Meijer G-function implemented in mpmath, but I don't know how to use it.
 """
 from ._special import gammaincc as _gammaincc
-from ._util import _jit, _generate_wrappers
+from ._util import _jit, _generate_wrappers, _prange
 import numpy as np
 
 _doc_par = """
@@ -31,8 +31,9 @@ mu : float
 @_jit(1, cache=False)
 def _cdf(x, mu):
     r = np.empty_like(x)
-    for i, xi in enumerate(x):
-        r[i] = _gammaincc(xi + type(xi)(1), mu)
+    one = type(x[0])(1)
+    for i in _prange(len(x)):
+        r[i] = _gammaincc(x[i] + one, mu)
     return r
 
 

--- a/src/numba_stats/crystalball.py
+++ b/src/numba_stats/crystalball.py
@@ -10,7 +10,7 @@ See Also
 --------
 scipy.stats.crystalball: Scipy equivalent.
 """
-from ._util import _jit, _trans, _generate_wrappers
+from ._util import _jit, _trans, _generate_wrappers, _prange
 import numpy as np
 from math import erf as _erf
 
@@ -66,8 +66,8 @@ def _logpdf(x, beta, m, loc, scale):
         _powerlaw_integral(-beta, beta, m) + _normal_integral(-beta, type(beta)(np.inf))
     )
     c = np.log(norm)
-    for i, zi in enumerate(z):
-        z[i] = _log_density(zi, beta, m) - c
+    for i in _prange(len(z)):
+        z[i] = _log_density(z[i], beta, m) - c
     return z
 
 
@@ -82,12 +82,12 @@ def _cdf(x, beta, m, loc, scale):
     norm = _powerlaw_integral(-beta, beta, m) + _normal_integral(
         -beta, type(beta)(np.inf)
     )
-    for i, zi in enumerate(z):
-        if zi < -beta:
-            z[i] = _powerlaw_integral(zi, beta, m) / norm
+    for i in _prange(len(z)):
+        if z[i] < -beta:
+            z[i] = _powerlaw_integral(z[i], beta, m) / norm
         else:
             z[i] = (
-                _powerlaw_integral(-beta, beta, m) + _normal_integral(-beta, zi)
+                _powerlaw_integral(-beta, beta, m) + _normal_integral(-beta, z[i])
             ) / norm
     return z
 

--- a/src/numba_stats/crystalball.py
+++ b/src/numba_stats/crystalball.py
@@ -27,7 +27,8 @@ m : float
 
 @_jit(-3)
 def _log_powerlaw(z, beta, m):
-    c = -type(beta)(0.5) * beta * beta
+    T = type(beta)
+    c = -T(0.5) * beta * beta
     log_a = m * np.log(m / beta) + c
     b = m / beta - beta
     return log_a - m * np.log(b - z)
@@ -35,7 +36,8 @@ def _log_powerlaw(z, beta, m):
 
 @_jit(-3)
 def _powerlaw_integral(z, beta, m):
-    exp_beta = np.exp(-type(beta)(0.5) * beta * beta)
+    T = type(beta)
+    exp_beta = np.exp(-T(0.5) * beta * beta)
     a = (m / beta) ** m * exp_beta
     b = m / beta - beta
     m1 = m - type(m)(1)
@@ -44,12 +46,9 @@ def _powerlaw_integral(z, beta, m):
 
 @_jit(-2)
 def _normal_integral(a, b):
-    sqrt_half = np.sqrt(type(a)(0.5))
-    return (
-        sqrt_half
-        * np.sqrt(type(a)(np.pi))
-        * (_erf(b * sqrt_half) - _erf(a * sqrt_half))
-    )
+    T = type(a)
+    sqrt_half = np.sqrt(T(0.5))
+    return sqrt_half * np.sqrt(T(np.pi)) * (_erf(b * sqrt_half) - _erf(a * sqrt_half))
 
 
 @_jit(-3)

--- a/src/numba_stats/crystalball_ex.py
+++ b/src/numba_stats/crystalball_ex.py
@@ -82,7 +82,7 @@ def _cdf(x, beta_left, m_left, scale_left, beta_right, m_right, scale_right, loc
         beta_right, m_right, scale_right
     )
     r = np.empty_like(x)
-    for i in range(len(x)):
+    for i in _prange(len(x)):
         scale = T(1) / (scale_left if x[i] < loc else scale_right)
         z = (x[i] - loc) * scale
         if z < -beta_left:

--- a/src/numba_stats/crystalball_ex.py
+++ b/src/numba_stats/crystalball_ex.py
@@ -8,7 +8,7 @@ discontinuity at the maximum or elsewhere.
 """
 
 from .crystalball import _powerlaw_integral, _normal_integral, _log_density
-from ._util import _jit, _generate_wrappers
+from ._util import _jit, _generate_wrappers, _prange
 import numpy as np
 
 _doc_par = """
@@ -47,15 +47,15 @@ def _logpdf(x, beta_left, m_left, scale_left, beta_right, m_right, scale_right, 
     )
     c = np.log(norm)
     r = np.empty_like(x)
-    for i, xi in enumerate(x):
-        if xi < loc:
+    for i in _prange(len(r)):
+        if x[i] < loc:
             beta = beta_left
             m = m_left
-            z = (xi - loc) * (type(scale_left)(1) / scale_left)
+            z = (x[i] - loc) * (type(scale_left)(1) / scale_left)
         else:
             beta = beta_right
             m = m_right
-            z = (loc - xi) * (type(scale_right)(1) / scale_right)
+            z = (loc - x[i]) * (type(scale_right)(1) / scale_right)
         r[i] = _log_density(z, beta, m) - c
     return r
 
@@ -82,9 +82,9 @@ def _cdf(x, beta_left, m_left, scale_left, beta_right, m_right, scale_right, loc
         beta_right, m_right, scale_right
     )
     r = np.empty_like(x)
-    for i, xi in enumerate(x):
-        scale = type(scale_left)(1) / (scale_left if xi < loc else scale_right)
-        z = (xi - loc) * scale
+    for i in _prange(len(x)):
+        scale = type(scale_left)(1) / (scale_left if x[i] < loc else scale_right)
+        z = (x[i] - loc) * scale
         if z < -beta_left:
             r[i] = _powerlaw_integral(z, beta_left, m_left) * scale_left / norm
         elif z < 0:

--- a/src/numba_stats/crystalball_ex.py
+++ b/src/numba_stats/crystalball_ex.py
@@ -35,9 +35,8 @@ loc : float
 
 @_jit(-3)
 def _norm_half(beta, m, scale):
-    return (
-        _powerlaw_integral(-beta, beta, m) + _normal_integral(-beta, type(beta)(0))
-    ) * scale
+    T = type(beta)
+    return (_powerlaw_integral(-beta, beta, m) + _normal_integral(-beta, T(0))) * scale
 
 
 @_jit(7)
@@ -51,11 +50,11 @@ def _logpdf(x, beta_left, m_left, scale_left, beta_right, m_right, scale_right, 
         if x[i] < loc:
             beta = beta_left
             m = m_left
-            z = (x[i] - loc) * (type(scale_left)(1) / scale_left)
+            z = (x[i] - loc) / scale_left
         else:
             beta = beta_right
             m = m_right
-            z = (loc - x[i]) * (type(scale_right)(1) / scale_right)
+            z = (loc - x[i]) / scale_right
         r[i] = _log_density(z, beta, m) - c
     return r
 
@@ -78,12 +77,13 @@ def _pdf(x, beta_left, m_left, scale_left, beta_right, m_right, scale_right, loc
 
 @_jit(7)
 def _cdf(x, beta_left, m_left, scale_left, beta_right, m_right, scale_right, loc):
+    T = type(beta_left)
     norm = _norm_half(beta_left, m_left, scale_left) + _norm_half(
         beta_right, m_right, scale_right
     )
     r = np.empty_like(x)
-    for i in _prange(len(x)):
-        scale = type(scale_left)(1) / (scale_left if x[i] < loc else scale_right)
+    for i in range(len(x)):
+        scale = T(1) / (scale_left if x[i] < loc else scale_right)
         z = (x[i] - loc) * scale
         if z < -beta_left:
             r[i] = _powerlaw_integral(z, beta_left, m_left) * scale_left / norm
@@ -100,20 +100,20 @@ def _cdf(x, beta_left, m_left, scale_left, beta_right, m_right, scale_right, loc
             r[i] = (
                 (
                     _powerlaw_integral(-beta_left, beta_left, m_left)
-                    + _normal_integral(-beta_left, type(beta_left)(0))
+                    + _normal_integral(-beta_left, T(0))
                 )
                 * scale_left
-                + _normal_integral(0, z) * scale_right
+                + _normal_integral(T(0), z) * scale_right
             ) / norm
         else:
             r[i] = (
                 (
                     _powerlaw_integral(-beta_left, beta_left, m_left)
-                    + _normal_integral(-beta_left, type(beta_left)(0))
+                    + _normal_integral(-beta_left, T(0))
                 )
                 * scale_left
                 + (
-                    _normal_integral(type(beta_right)(0), beta_right)
+                    _normal_integral(T(0), beta_right)
                     + _powerlaw_integral(-beta_right, beta_right, m_right)
                     - _powerlaw_integral(-z, beta_right, m_right)
                 )

--- a/src/numba_stats/expon.py
+++ b/src/numba_stats/expon.py
@@ -7,7 +7,7 @@ scipy.stats.expon: Scipy equivalent.
 """
 import numpy as np
 from math import expm1 as _expm1, log1p as _log1p
-from ._util import _jit, _trans, _generate_wrappers
+from ._util import _jit, _trans, _generate_wrappers, _prange
 
 _doc_par = """
 x: ArrayLike
@@ -77,16 +77,16 @@ def _cdf(x, loc, scale):
         Function evaluated at x.
     """
     z = _trans(x, loc, scale)
-    for i, zi in enumerate(z):
-        z[i] = _cdf1(zi)
+    for i in _prange(len(z)):
+        z[i] = _cdf1(z[i])
     return z
 
 
 @_jit(2)
 def _ppf(p, loc, scale):
     z = np.empty_like(p)
-    for i, pi in enumerate(p):
-        z[i] = _ppf1(pi)
+    for i in _prange(len(z)):
+        z[i] = _ppf1(p[i])
     return scale * z + loc
 
 

--- a/src/numba_stats/norm.py
+++ b/src/numba_stats/norm.py
@@ -7,7 +7,7 @@ scipy.stats.norm: Scipy equivalent.
 """
 import numpy as np
 from ._special import erfinv as _erfinv
-from ._util import _jit, _trans, _generate_wrappers
+from ._util import _jit, _trans, _generate_wrappers, _prange
 from math import erf as _erf
 
 _doc_par = """
@@ -42,8 +42,8 @@ def _ppf1(p):
 @_jit(2)
 def _logpdf(x, loc, scale):
     r = _trans(x, loc, scale)
-    for i, ri in enumerate(r):
-        r[i] = _logpdf1(ri) - np.log(scale)
+    for i in _prange(len(r)):
+        r[i] = _logpdf1(r[i]) - np.log(scale)
     return r
 
 
@@ -55,16 +55,16 @@ def _pdf(x, loc, scale):
 @_jit(2)
 def _cdf(x, loc, scale):
     r = _trans(x, loc, scale)
-    for i, ri in enumerate(r):
-        r[i] = _cdf1(ri)
+    for i in _prange(len(r)):
+        r[i] = _cdf1(r[i])
     return r
 
 
 @_jit(2, cache=False)
 def _ppf(p, loc, scale):
     r = np.empty_like(p)
-    for i, pi in enumerate(p):
-        r[i] = scale * _ppf1(pi) + loc
+    for i in _prange(len(r)):
+        r[i] = scale * _ppf1(p[i]) + loc
     return r
 
 

--- a/src/numba_stats/poisson.py
+++ b/src/numba_stats/poisson.py
@@ -9,7 +9,7 @@ scipy.stats.poisson: Scipy equivalent.
 import numpy as np
 from ._special import gammaincc as _gammaincc
 from math import lgamma as _lgamma
-from ._util import _jit, _generate_wrappers
+from ._util import _jit, _generate_wrappers, _prange
 
 _doc_par = """
 x : ArrayLike
@@ -23,11 +23,11 @@ mu : float
 def _logpmf(k, mu):
     T = type(mu)
     r = np.empty(len(k), T)
-    for i, ki in enumerate(k):
+    for i in _prange(len(r)):
         if mu == 0:
-            r[i] = 0.0 if ki == 0 else -np.inf
+            r[i] = 0.0 if k[i] == 0 else -np.inf
         else:
-            r[i] = ki * np.log(mu) - _lgamma(ki + T(1)) - mu
+            r[i] = k[i] * np.log(mu) - _lgamma(k[i] + T(1)) - mu
     return r
 
 
@@ -40,8 +40,8 @@ def _pmf(k, mu):
 def _cdf(k, mu):
     T = type(mu)
     r = np.empty(len(k), T)
-    for i, ki in enumerate(k):
-        r[i] = _gammaincc(ki + T(1), mu)
+    for i in _prange(len(r)):
+        r[i] = _gammaincc(k[i] + T(1), mu)
     return r
 
 

--- a/src/numba_stats/uniform.py
+++ b/src/numba_stats/uniform.py
@@ -5,7 +5,7 @@ See Also
 --------
 scipy.stats.uniform: Equivalent in Scipy.
 """
-from ._util import _jit, _generate_wrappers
+from ._util import _jit, _generate_wrappers, _prange
 import numpy as np
 
 _doc_par = """
@@ -21,8 +21,8 @@ w : float
 @_jit(2)
 def _logpdf(x, a, w):
     r = np.empty_like(x)
-    for i, xi in enumerate(x):
-        if a <= xi <= a + w:
+    for i in _prange(len(x)):
+        if a <= x[i] <= a + w:
             r[i] = -np.log(w)
         else:
             r[i] = -np.inf
@@ -37,10 +37,10 @@ def _pdf(x, a, w):
 @_jit(2)
 def _cdf(x, a, w):
     r = np.empty_like(x)
-    for i, xi in enumerate(x):
-        if a <= xi:
-            if xi <= a + w:
-                r[i] = (xi - a) / w
+    for i in _prange(len(x)):
+        if a <= x[i]:
+            if x[i] <= a + w:
+                r[i] = (x[i] - a) / w
             else:
                 r[i] = 1
         else:

--- a/src/numba_stats/voigt.py
+++ b/src/numba_stats/voigt.py
@@ -13,7 +13,7 @@ See Also
 scipy.special.voigt_profile: Equvialent in Scipy.
 """
 from ._special import voigt_profile as _voigt
-from ._util import _jit, _generate_wrappers
+from ._util import _jit, _generate_wrappers, _prange
 import numpy as np
 
 _doc_par = """
@@ -31,8 +31,8 @@ scale : float
 @_jit(3, cache=False)
 def _pdf(x, gamma, loc, scale):
     r = np.empty_like(x)
-    for i, xi in enumerate(x):
-        r[i] = _voigt(xi - loc, scale, gamma)
+    for i in _prange(len(x)):
+        r[i] = _voigt(x[i] - loc, scale, gamma)
     return r
 
 

--- a/tests/test_bernstein.py
+++ b/tests/test_bernstein.py
@@ -44,8 +44,10 @@ def test_integral_2(beta):
     assert_allclose(got, expected)
 
 
+@pytest.mark.filterwarnings("error")
 @pytest.mark.parametrize("parallel", (False, True))
-def test_numba_density(parallel):
+@pytest.mark.parametrize("fn", [bernstein.density, bernstein.integral])
+def test_numba(fn, parallel):
     x = np.linspace(0.5, 0.6, 10000)
     beta = np.array([1.0, 2.0, 3.0])
     xmin = 1.0
@@ -53,22 +55,9 @@ def test_numba_density(parallel):
 
     @nb.njit(parallel=parallel, fastmath=True)
     def f():
-        return bernstein.density(x, beta, xmin, xmax)
+        return fn(x, beta, xmin, xmax)
 
-    assert_allclose(f(), bernstein.density(x, beta, xmin, xmax))
-
-
-def test_numba_integral():
-    x = np.linspace(0.5, 0.6, 1000)
-    beta = np.array([1.0, 2.0, 3.0])
-    xmin = 1.0
-    xmax = 2.5
-
-    @nb.njit
-    def f():
-        return bernstein.integral(x, beta, xmin, xmax)
-
-    assert_allclose(f(), bernstein.integral(x, beta, xmin, xmax))
+    assert_allclose(f(), fn(x, beta, xmin, xmax))
 
 
 def test_deprecation():


### PR DESCRIPTION
This patch enables the parallelized computations of a function provided by this library if it is used in another function decorated with `numba.njit(parallel=True)`.