### PR TITLE
Add some universal functions, and use them for implementing the Norm and Poisson PPF

### DIFF
--- a/src/numba_stats/_special.py
+++ b/src/numba_stats/_special.py
@@ -26,7 +26,6 @@ def get(name, signature):
 
 
 # unary functions (double)
-erfinv = get("erfinv", float64(float64))
 
 # binary functions (double)
 gammaincc = get("gammaincc", float64(float64, float64))

--- a/src/numba_stats/lognorm.py
+++ b/src/numba_stats/lognorm.py
@@ -51,7 +51,7 @@ def _cdf(x, s, loc, scale):
     return r
 
 
-@_jit(3, cache=False)  # no cache because of norm._ppf
+@_jit(3)
 def _ppf(p, s, loc, scale):
     r = np.empty_like(p)
     for i in _prange(len(p)):

--- a/src/numba_stats/norm.py
+++ b/src/numba_stats/norm.py
@@ -6,7 +6,7 @@ See Also
 scipy.stats.norm: Scipy equivalent.
 """
 import numpy as np
-from ._special import erfinv as _erfinv
+from .special import erfinv as _erfinv
 from ._util import _jit, _trans, _generate_wrappers, _prange
 from math import erf as _erf
 
@@ -33,7 +33,7 @@ def _cdf1(z):
     return T(0.5) * (T(1.0) + _erf(z * c))
 
 
-@_jit(-1, cache=False)  # cannot cache because of _erfinv
+@_jit(-1)
 def _ppf1(p):
     T = type(p)
     return T(np.sqrt(2)) * _erfinv(T(2) * p - T(1))
@@ -60,7 +60,7 @@ def _cdf(x, loc, scale):
     return r
 
 
-@_jit(2, cache=False)
+@_jit(2)
 def _ppf(p, loc, scale):
     r = np.empty_like(p)
     for i in _prange(len(r)):

--- a/src/numba_stats/poisson.py
+++ b/src/numba_stats/poisson.py
@@ -10,6 +10,8 @@ import numpy as np
 from ._special import gammaincc as _gammaincc
 from math import lgamma as _lgamma
 from ._util import _jit, _generate_wrappers, _prange
+from .special import erfinv as _erfinv
+from math import erfc as _erfc
 
 _doc_par = """
 x : ArrayLike
@@ -42,6 +44,211 @@ def _cdf(k, mu):
     r = np.empty(len(k), T)
     for i in _prange(len(r)):
         r[i] = _gammaincc(k[i] + T(1), mu)
+    return r
+
+
+@_jit(-2)
+def _ppf1(u, lam):
+    v = 1.0 - u
+    if u == 0.0:
+        return 0.0
+    if v == 0.0:
+        return np.inf
+    if not (u > 0.0 and v > 0.0):
+        return np.nan
+
+    x = 0.0
+    lam_inv = 1 / lam
+    sq2 = np.sqrt(2)
+
+    if lam > 4.0:
+        w = sq2 * _erfinv(2 * np.minimum(u, v) - 1)
+        if u > v:
+            w = -w
+
+        if np.abs(w) < 3.0:
+            lr = np.sqrt(lam)
+            s = lr * w + (1.0 / 3.0 + (1.0 / 6.0) * w * w) * (1.0 - w / (12.0 * lr))
+
+            d = 1.0 / 160.0
+            d = (1.0 / 80.0) + d * (w * w)
+            d = (1.0 / 40.0) + d * (w * w)
+            d = d * lam_inv
+
+            s = lam + (s + d)
+        else:
+            s = w / np.sqrt(lam)
+            r = 1.0 + s
+            if r < 0.1:
+                r = 0.1
+            r2 = 0.0
+
+            while np.abs(r - r2) > 1e-8:
+                t = np.log(r)
+                r2 = r
+                s2 = np.sqrt(2.0 * ((1.0 - r) + r * t))
+                if r < 1.0:
+                    s2 = -s2
+                r = r2 - (s2 - s) * s2 / t
+                if r < 0.1 * r2:
+                    r = 0.1 * r2
+
+            t = np.log(r)
+            s = (
+                lam * r
+                + np.log(np.sqrt(2.0 * r * ((1.0 - r) + r * t)) / np.abs(r - 1.0)) / t
+            )
+            s = s - 0.0218 / (s + 0.065 * lam)
+            d = 0.01 / s
+            s = s + d
+
+        x = np.floor(s)
+
+        if 10.0 < s < x + 2.0 * d:
+            xi = 1.0 / x
+            eta = x * lam_inv
+            eta = np.sqrt(2.0 * (1.0 - eta + eta * np.log(eta)) / eta)
+            if x > lam:
+                eta = -eta
+
+            b1 = 8.0995211567045583e-16
+            s = b1
+            b0 = -1.9752288294349411e-15
+            s = b0 + s * eta
+            b1 = -5.1391118342426808e-16 + 25.0 * b1 * xi
+            s = b1 + s * eta
+            b0 = 2.8534893807047458e-14 + 24.0 * b0 * xi
+            s = b0 + s * eta
+            b1 = -1.3923887224181616e-13 + 23.0 * b1 * xi
+            s = b1 + s * eta
+            b0 = 3.3717632624009806e-13 + 22.0 * b0 * xi
+            s = b0 + s * eta
+            b1 = 1.1004392031956284e-13 + 21.0 * b1 * xi
+            s = b1 + s * eta
+            b0 = -5.0276692801141763e-12 + 20.0 * b0 * xi
+            s = b0 + s * eta
+            b1 = 2.4361948020667402e-11 + 19.0 * b1 * xi
+            s = b1 + s * eta
+            b0 = -5.8307721325504166e-11 + 18.0 * b0 * xi
+            s = b0 + s * eta
+            b1 = -2.5514193994946487e-11 + 17.0 * b1 * xi
+            s = b1 + s * eta
+            b0 = 9.1476995822367933e-10 + 16.0 * b0 * xi
+            s = b0 + s * eta
+            b1 = -4.3820360184533521e-09 + 15.0 * b1 * xi
+            s = b1 + s * eta
+            b0 = 1.0261809784240299e-08 + 14.0 * b0 * xi
+            s = b0 + s * eta
+            b1 = 6.7078535434015332e-09 + 13.0 * b1 * xi
+            s = b1 + s * eta
+            b0 = -1.7665952736826086e-07 + 12.0 * b0 * xi
+            s = b0 + s * eta
+            b1 = 8.2967113409530833e-07 + 11.0 * b1 * xi
+            s = b1 + s * eta
+            b0 = -1.8540622107151585e-06 + 10.0 * b0 * xi
+            s = b0 + s * eta
+            b1 = -2.1854485106799979e-06 + 9.0 * b1 * xi
+            s = b1 + s * eta
+            b0 = 3.9192631785224383e-05 + 8.0 * b0 * xi
+            s = b0 + s * eta
+            b1 = -0.00017875514403292177 + 7.0 * b1 * xi
+            s = b1 + s * eta
+            b0 = 0.00035273368606701921 + 6.0 * b0 * xi
+            s = b0 + s * eta
+            b1 = 0.0011574074074074078 + 5.0 * b1 * xi
+            s = b1 + s * eta
+            b0 = -0.014814814814814815 + 4.0 * b0 * xi
+            s = b0 + s * eta
+            b1 = 0.083333333333333329 + 3.0 * b1 * xi
+            s = b1 + s * eta
+            b0 = -0.33333333333333331 + 2.0 * b0 * xi
+            s = b0 + s * eta
+            s = s / (1.0 + b1 * xi)
+
+            # there is something strange in this formula
+            s = s * np.exp(-0.5 * x * eta * eta) / np.sqrt(2.0 * np.pi * x)
+            if x < lam:
+                s += 0.5 * _erfc(eta * np.sqrt(0.5 * x))
+                # s += 1.0 - norm.cdf(eta * np.sqrt(x), 0.0, 1.0)
+                if s > u:
+                    x -= 1.0
+            else:
+                s -= 0.5 * _erfc(-eta * np.sqrt(0.5 * x))
+                # s -= 1.0 - norm.cdf(-eta * np.sqrt(x), 0.0, 1.0)
+                if s > -v:
+                    x -= 1.0
+        else:
+            xi = 1.0 / x
+            s = -691.0 / 360360.0
+            s = 1.0 / 1188.0 + s * xi * xi
+            s = -1.0 / 1680.0 + s * xi * xi
+            s = 1.0 / 1260.0 + s * xi * xi
+            s = -1.0 / 360.0 + s * xi * xi
+            s = 1.0 / 12.0 + s * xi * xi
+            s = s * xi
+            s = (x - lam) - x * np.log(x * lam_inv) - s
+
+            if x < lam:
+                t = np.exp(-0.5 * s)
+                s = 1.0 - t * (u * t) * np.sqrt(2.0 * 3.141592653589793 * xi) * lam
+                t = 1.0
+                xi = x
+                for i in range(1, 50):
+                    xi -= 1.0
+                    t *= xi * lam_inv
+                    s += t
+
+                if s > 0.0:
+                    x -= 1.0
+            else:
+                t = np.exp(-0.5 * s)
+                s = 1.0 - t * (v * t) * np.sqrt(2.0 * 3.141592653589793 * x)
+                xi = x
+                for i in range(1, 50):
+                    xi += 1.0
+                    s = s * xi * lam_inv + 1.0
+
+                if s < 0.0:
+                    x -= 1.0
+
+    if x < 10.0:
+        x = 0.0
+        t = np.exp(0.5 * lam)
+        d = 0.0
+        if u > 0.5:
+            d = t * (1e-13 * t)
+        s = 1.0 - t * (u * t) + d
+
+        while s < 0.0:
+            x += 1.0
+            t = x * lam_inv
+            d = t * d
+            s = t * s + 1.0
+
+        if s < 2.0 * d:
+            d = 1e13 * d
+            t = 1e17 * d
+            d = v * d
+
+            while d < t:
+                x += 1.0
+                d *= x * lam_inv
+
+            s = d
+            t = 1.0
+            while s > 0.0:
+                t *= x * lam_inv
+                s -= t
+                x -= 1.0
+
+    return x
+
+
+@_jit(1)
+def _ppf(p, mu):
+    r = np.empty_like(p)
+    for i in _prange(len(r)):
+        r[i] = _ppf1(p[i], mu)
     return r
 
 

--- a/src/numba_stats/special/__init__.py
+++ b/src/numba_stats/special/__init__.py
@@ -1,0 +1,15 @@
+"""Universal functions.
+
+Port of special functions from cephes C library (https://github.com/jeremybarnes/cephes)
+or Scipy C implementations (see scipy.special).
+"""
+
+__all__ = [
+    "erfinv",
+    "ndtri",
+    "polevl",
+]
+
+from ._polevl import polevl
+from ._ndtri import ndtri
+from ._erfinv import erfinv

--- a/src/numba_stats/special/_erfinv.py
+++ b/src/numba_stats/special/_erfinv.py
@@ -1,0 +1,68 @@
+import numba as nb
+import numpy as np
+from numpy import inf, nan
+from ._ndtri import ndtri
+from .._util import _Floats, _trans
+
+
+@nb.njit([T(T) for T in _Floats], cache=True, inline="never", error_model="numpy")
+def erfinv(z):
+    """
+    Calculate the inverse error function at point ``z``.
+
+    This is a direct port of the SciPy ``erfinv`` function, originally
+    written in C.
+
+    Parameters
+    ----------
+    z : float
+
+    Returns
+    -------
+    float
+
+    References
+    ----------
+    + https://en.wikipedia.org/wiki/Error_function#Inverse_functions
+    + http://functions.wolfram.com/GammaBetaErf/InverseErf/
+
+    Examples
+    --------
+    >>> import math
+    >>> round(erfinv(0.1), 12)
+    0.088855990494
+    >>> round(erfinv(0.5), 12)
+    0.476936276204
+    >>> round(erfinv(-0.5), 12)
+    -0.476936276204
+    >>> round(erfinv(0.95), 12)
+    1.38590382435
+    >>> round(math.erf(erfinv(0.3)), 3)
+    0.3
+    >>> round(erfinv(math.erf(0.5)), 3)
+    0.5
+    >>> erfinv(0)
+    0
+    >>> erfinv(1)
+    inf
+    >>> erfinv(-1)
+    -inf
+    """
+    T = type(z)
+    if np.abs(z) > T(1):
+        # If z < -1 or z > 1, we return NaN.
+        # TBD: Should the function raise ValueError, signalling explicitly that
+        # `z` must be between -1 and 1 inclusive?
+        return nan
+
+    # Shortcut special cases
+    if z == T(0):
+        return T(0)
+    if z == T(1):
+        return inf
+    if z == T(-1):
+        return -inf
+
+    # otherwise calculate things.
+    inv_sqrt_2 = T(1) / np.sqrt(T(2))
+    return ndtri(_trans(z, T(-1), T(2))) * inv_sqrt_2

--- a/src/numba_stats/special/_ndtri.py
+++ b/src/numba_stats/special/_ndtri.py
@@ -1,0 +1,133 @@
+"""Port of cephes ``ndtri.c``.
+
+See https://github.com/jeremybarnes/cephes/blob/master/cprob/ndtri.c
+"""
+
+import numba as nb
+import numpy as np
+from numpy import pi
+from ._polevl import polevl
+from .._util import _Floats
+
+
+@nb.njit([T(T) for T in _Floats], cache=True, inline="never", error_model="numpy")
+def ndtri(y):
+    """Inverse of Normal distribution function."""
+    T = type(y)
+    root_2_pi = np.sqrt(T(2 * pi))
+    exp_neg2 = np.exp(T(-2))
+
+    # approximation for 0 <= abs(y - 0.5) <= 3/8
+    p0 = np.array(
+        [
+            -1.23916583867381258016e0,
+            1.39312609387279679503e1,
+            -5.66762857469070293439e1,
+            9.80010754185999661536e1,
+            -5.99633501014107895267e1,
+        ]
+    )
+
+    q0 = np.array(
+        [
+            -1.18331621121330003142e0,
+            1.59056225126211695515e1,
+            -8.20372256168333339912e1,
+            2.00260212380060660359e2,
+            -2.25462687854119370527e2,
+            8.63602421390890590575e1,
+            4.67627912898881538453e0,
+            1.95448858338141759834e0,
+            1.0,
+        ]
+    )
+
+    # Approximation for interval z = sqrt(-2 log y ) between 2 and 8
+    # i.e., y between exp(-2) = .135 and exp(-32) = 1.27e-14.
+    p1 = np.array(
+        [
+            -8.57456785154685413611e-4,
+            -3.50424626827848203418e-2,
+            -1.40256079171354495875e-1,
+            2.18663306850790267539e0,
+            1.46849561928858024014e1,
+            4.40805073893200834700e1,
+            5.71628192246421288162e1,
+            3.15251094599893866154e1,
+            4.05544892305962419923e0,
+        ]
+    )
+
+    q1 = np.array(
+        [
+            -9.33259480895457427372e-4,
+            -3.80806407691578277194e-2,
+            -1.42182922854787788574e-1,
+            2.50464946208309415979e0,
+            1.50425385692907503408e1,
+            4.13172038254672030440e1,
+            4.53907635128879210584e1,
+            1.57799883256466749731e1,
+            1.0,
+        ]
+    )
+
+    # Approximation for interval z = sqrt(-2 log y ) between 8 and 64
+    # i.e., y between exp(-32) = 1.27e-14 and exp(-2048) = 3.67e-890.
+    p2 = np.array(
+        [
+            6.23974539184983293730e-9,
+            2.65806974686737550832e-6,
+            3.01581553508235416007e-4,
+            1.23716634817820021358e-2,
+            2.01485389549179081538e-1,
+            1.33303460815807542389e0,
+            3.93881025292474443415e0,
+            6.91522889068984211695e0,
+            3.23774891776946035970e0,
+        ]
+    )
+
+    q2 = np.array(
+        [
+            6.79019408009981274425e-9,
+            2.89247864745380683936e-6,
+            3.28014464682127739104e-4,
+            1.34204006088543189037e-2,
+            2.16236993594496635890e-1,
+            1.37702099489081330271e0,
+            3.67983563856160859403e0,
+            6.02427039364742014255e0,
+            1.0,
+        ]
+    )
+
+    sign_flag = 1
+
+    if y > (T(1) - exp_neg2):
+        y = T(1) - y
+        sign_flag = 0
+
+    # Shortcut case where we don't need high precision
+    # between -0.135 and 0.135
+    if y > exp_neg2:
+        y -= T(0.5)
+        y2 = y**2
+        x = y + y * (y2 * polevl(y2, p0) / polevl(y2, q0))
+        x = x * root_2_pi
+        return x
+
+    x = np.sqrt(T(-2) * np.log(y))
+    z = np.reciprocal(x)
+    x0 = x - np.log(x) * z
+
+    if x < T(8.0):  # y > exp(-32) = 1.2664165549e-14
+        x1 = z * polevl(z, p1) / polevl(z, q1)
+    else:
+        x1 = z * polevl(z, p2) / polevl(z, q2)
+
+    x = x0 - x1
+    if sign_flag != 0:
+        x = -x
+
+    return x

--- a/src/numba_stats/special/_polevl.py
+++ b/src/numba_stats/special/_polevl.py
@@ -1,0 +1,35 @@
+"""Port of cephes ``polevl.c``.
+
+See https://github.com/jeremybarnes/cephes/blob/master/cprob/polevl.c
+"""
+import numba as nb
+from .._util import _Floats, _readonly_carray, _prange
+
+
+@nb.njit(
+    [T(T, _readonly_carray(T)) for T in _Floats],
+    cache=True,
+    inline="never",
+    error_model="numpy",
+)
+def polevl(x, coefs):
+    """
+    Evaluate polynomial using Horner's method.
+
+    The degree N of the polynomial is inferred by the **coefs** array.
+    In this implementation, though, coefficients are stored in increasing degree order:
+    p(x) = c_0 + c_1 * x + ... + c_N * x^N
+    where **coefs** is an array with N + 1 length such that
+    coefs[0] = c_0, ..., coefs[N] = c_N
+    """
+    len_coefs = len(coefs)
+    ans = coefs[-1]
+    try:
+        for i in _prange(2, len_coefs + 1):
+            ans = ans * x + coefs[-i]
+    except Exception:
+        # The exception to be catched should be OverflowError,
+        # but numba rejects it as the implementation raised a specific error:
+        # UnsupportedError: Exception matching is limited to <class 'Exception'>
+        pass
+    return ans

--- a/src/numba_stats/truncnorm.py
+++ b/src/numba_stats/truncnorm.py
@@ -64,7 +64,7 @@ def _cdf(x, xmin, xmax, loc, scale):
     return r
 
 
-@_jit(4, cache=False)
+@_jit(4)
 def _ppf(p, xmin, xmax, loc, scale):
     scale2 = type(scale)(1) / scale
     zmin = (xmin - loc) * scale2

--- a/tests/test_poisson.py
+++ b/tests/test_poisson.py
@@ -18,3 +18,11 @@ def test_cdf(mu):
     got = poisson.cdf(k, mu)
     expected = sc.poisson.cdf(k, mu)
     np.testing.assert_allclose(got, expected)
+
+
+@pytest.mark.parametrize("mu", np.linspace(0, 3, 5))
+def test_ppf(mu):
+    k = np.random.uniform(10)
+    got = poisson.ppf(k, mu)
+    expected = sc.poisson.ppf(k, mu)
+    np.testing.assert_allclose(got, expected)


### PR DESCRIPTION
Implement some universal functions in a numba-friendly numpy jargon, and use them for Norm and Poisson PPF, which should be numba-cached and, possibly, inlined.

* Add numba-friendly (and cached) Numpy version of 1D polynomial evaluation using Horner's method: the implementation is inspired by `cephes` and `numpy.polynomial.polynomial.polyval`.
* Add JIT-ed Inverse Normal distribution function from `cephes` (numba-cached)
* Add JIT-ed erfinv from `scipy` (numba-cached)
* Add JIT-ed Poisson PPF (numba-cached)
* Allow Norm PPF to be numba-cached.

As you can see, the universal functions are cached, but not inlined. This is due to a bug in `numba`, which should be solved in the upcoming 0.56 release.
See https://github.com/numba/numba/issues/7802 for more details.