### PR TITLE
add cruijff function

### DIFF
--- a/src/numba_stats/_util.py
+++ b/src/numba_stats/_util.py
@@ -88,6 +88,7 @@ def _generate_wrappers(d):
         args = inspect.signature(fn).parameters
         args = ", ".join([f"{x}" for x in args])
         doc_title = {
+            "density": "Return density.",
             "logpdf": "Return log of probability density.",
             "logpmf": "Return log of probability mass.",
             "pmf": "Return probability mass.",

--- a/src/numba_stats/cruijff.py
+++ b/src/numba_stats/cruijff.py
@@ -6,64 +6,36 @@ See For example: https://arxiv.org/abs/1005.4087
 
 from ._util import _jit, _generate_wrappers, _prange
 import numpy as np
-from scipy.integrate import quad
-import numba
 
 _doc_par = """
 x : ArrayLike
     Random variate.
-mean : float
-    mean of the distribution
-sigma_left : float
-    left width
-sigma_right: float
-    right width
-alpha_left: float
-    left tail parameter
-alpha_right: float
-    right tail parameter
+beta_left: float
+    Left tail acceleration parameter.
+beta_right: float
+    Right tail acceleration parameter.
+loc : float
+    Location of the maximum of the distribution.
+scale_left : float
+    Left width parameter.
+scale_right: float
+    Right width parameter.
 """
 
 
-@_jit(-4)
-def _logpdf_gen(x, mean, sigma, alpha):
-    return -((x - mean) ** 2) / (2 * sigma * sigma + alpha * (x - mean) ** 2)
-
-
-@_jit(5)
-def _logpdf(x, mean, sigma_left, sigma_right, alpha_left, alpha_right):
+@_jit(6)
+def _density(x, ymax, beta_left, beta_right, loc, scale_left, scale_right):
     r = np.empty_like(x)
     for i in _prange(len(x)):
-        if x[i] < mean:
-            r[i] = _logpdf_gen(x[i], mean, sigma_left, alpha_left)
-        elif x[i] > mean:
-            r[i] = _logpdf_gen(x[i], mean, sigma_right, alpha_right)
-    return r
-
-
-@_jit(5)
-def _density(x, mean, sigma_left, sigma_right, alpha_left, alpha_right):
-    return np.exp(_logpdf(x, mean, sigma_left, sigma_right, alpha_left, alpha_right))
-
-
-@_jit(-5)
-def _norm(mean, sigma_left, sigma_right, alpha_left, alpha_right):
-    with numba.objmode(value="float"):
-        (value,) = quad(
-            lambda x: _density(
-                x, mean, sigma_left, sigma_right, alpha_left, alpha_right
-            ),
-            -np.inf,
-            np.inf,
-        )
-    return value
-
-
-@_jit(5)
-def _pdf(x, mean, sigma_left, sigma_right, alpha_left, alpha_right):
-    return _density(x, mean, sigma_left, sigma_right, alpha_left, alpha_right) / _norm(
-        mean, sigma_left, sigma_right, alpha_left, alpha_right
-    )
+        if x[i] < loc:
+            scale = scale_left
+            beta = beta_left
+        else:
+            scale = scale_right
+            beta = beta_right
+        z = (x[i] - loc) / scale
+        r[i] = -0.5 * z**2 / (1 + beta * z**2)
+    return ymax * np.exp(r)
 
 
 _generate_wrappers(globals())

--- a/src/numba_stats/cruijff.py
+++ b/src/numba_stats/cruijff.py
@@ -1,0 +1,47 @@
+"""
+Cruijff distribution.
+
+See For example: https://arxiv.org/abs/1005.4087
+"""
+
+from ._util import _jit, _generate_wrappers, _prange
+import numpy as np
+
+_doc_par = """
+x : ArrayLike
+    Random variate.
+mean : float
+    mean of the distribution
+sigma_left : float
+    left width
+sigma_right: float
+    right width
+alpha_left: float
+    left tail parameter
+alpha_right: float
+    right tail parameter
+"""
+
+
+@_jit(-4)
+def _logpdf_gen(x, mean, sigma, alpha):
+    return -((x - mean) ** 2) / (2 * sigma * sigma + alpha * (x - mean) ** 2)
+
+
+@_jit(5)
+def _logpdf(x, mean, sigma_left, sigma_right, alpha_left, alpha_right):
+    r = np.empty_like(x)
+    for i in _prange(len(x)):
+        if x[i] < mean:
+            r[i] = _logpdf_gen(x[i], mean, sigma_left, alpha_left)
+        elif x[i] > mean:
+            r[i] = _logpdf_gen(x[i], mean, sigma_right, alpha_right)
+    return r
+
+
+@_jit(5)
+def _pdf(x, mean, sigma_left, sigma_right, alpha_left, alpha_right):
+    return np.exp(_logpdf(x, mean, sigma_left, sigma_right, alpha_left, alpha_right))
+
+
+_generate_wrappers(globals())

--- a/tests/test_cruijff.py
+++ b/tests/test_cruijff.py
@@ -2,11 +2,29 @@ from numba_stats import cruijff
 import numpy as np
 from scipy.stats import norm
 from numpy.testing import assert_allclose
-import math
 
 
-def test_pdf():
+def test_density_1():
     x = np.linspace(-5, 5, 100)
-    got = cruijff.density(x, 0, 1, 1, 0, 0)
-    expected = norm().pdf(x) * math.sqrt(2 * math.pi)  # scale by root(2pi)
+    got = cruijff.density(x, 1 / np.sqrt(2 * np.pi), 0, 0, 0, 1, 1)
+    expected = norm().pdf(x)
     assert_allclose(got, expected)
+
+
+def test_density_2():
+    x = np.linspace(-5, 5, 100)
+    got = cruijff.density(x, 1, 0.1, 0.2, 1.5, 2.1, 2.1)
+    expected = cruijff.density((x - 1.5) / 2.1, 1, 0.1, 0.2, 0, 1, 1)
+    assert_allclose(got, expected)
+
+
+def test_density_3():
+    x = np.linspace(-5, 5, 100)
+    y = cruijff.density(x, 1, 0.2, 0.3, 0, 1.1, 1.2)
+    dy = np.diff(y, 1)
+    # density should be smooth
+    assert_allclose(dy, 0, atol=0.05)
+    # function rises up to x = 0
+    assert np.all(dy[x[1:] < 0] > 0)
+    # function falls after x = 0
+    assert np.all(dy[x[1:] > 0.1] < 0)

--- a/tests/test_cruijff.py
+++ b/tests/test_cruijff.py
@@ -1,0 +1,12 @@
+from numba_stats import cruijff
+import numpy as np
+from scipy.stats import norm
+from numpy.testing import assert_allclose
+import math
+
+
+def test_pdf():
+    x = np.linspace(-5, 5, 100)
+    got = cruijff.pdf(x, 0, 1, 1, 0, 0)
+    expected = norm().pdf(x) * math.sqrt(2 * math.pi)  # scale by root(2pi)
+    assert_allclose(got, expected)

--- a/tests/test_cruijff.py
+++ b/tests/test_cruijff.py
@@ -7,6 +7,6 @@ import math
 
 def test_pdf():
     x = np.linspace(-5, 5, 100)
-    got = cruijff.pdf(x, 0, 1, 1, 0, 0)
+    got = cruijff.density(x, 0, 1, 1, 0, 0)
     expected = norm().pdf(x) * math.sqrt(2 * math.pi)  # scale by root(2pi)
     assert_allclose(got, expected)


### PR DESCRIPTION
Hi @HDembinski 

This PR is regarding  #40 

## Description: 

This PR adds a Cruijff distribution
At present access to pdf and logpdf are provided

## Checks:

If we choose the following parameters, then we expect gaussian distributions with sigma 1 and mean 0:
alpha_left = 0
alpha_right = 0
sigma_right = 1
sigma_left = 1
mean = 0

Comparing with scipy.stats.norm
```code
from numba_stats import cruijff
import numpy as np
import matplotlib.pyplot as plt
from scipy.stats import norm
import math
x = np.linspace(-5, 5, 100)
y = cruijff.pdf(x,0,1,1,0,0)
z = norm().pdf(x)*math.sqrt(2*math.pi) # scale by root(2pi)
plt.plot(x,y,label='cruijff')
plt.plot(x,z, label='gauss')
plt.legend()
```