### PR TITLE
fix norm._ppf1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 write_to = "src/numba_stats/_version.py"
 
+[tool.ruff]
+max-length = 90
+
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "-q -ra --ff"

--- a/src/numba_stats/_special.py
+++ b/src/numba_stats/_special.py
@@ -4,16 +4,17 @@
 # scipy to implement the needed functions here.
 from numba.extending import get_cython_function_address
 from numba.types import WrapperAddressProtocol, float64
-import scipy.special.cython_special as cysp
+
+# import scipy.special.cython_special as cysp
 
 
 def get(name, signature):
     # create new function object with correct signature that numba can call by extracting
     # function pointer from scipy.special.cython_special; uses scipy/cython internals
-    index = 1 if signature.return_type is float64 else 0
-    pyx_fuse_name = f"__pyx_fuse_{index}{name}"
-    if pyx_fuse_name in cysp.__pyx_capi__:
-        name = pyx_fuse_name
+    # index = 1 if signature.return_type is float64 else 0
+    # pyx_fuse_name = f"__pyx_fuse_{index}{name}"
+    # if pyx_fuse_name in cysp.__pyx_capi__:
+    #     name = pyx_fuse_name
     addr = get_cython_function_address("scipy.special.cython_special", name)
 
     # dynamically create type that inherits from WrapperAddressProtocol
@@ -26,7 +27,7 @@ def get(name, signature):
 
 
 # unary functions (double)
-erfinv = get("erfinv", float64(float64))
+ndtri = get("ndtri", float64(float64))
 
 # binary functions (double)
 gammaincc = get("gammaincc", float64(float64, float64))

--- a/src/numba_stats/_util.py
+++ b/src/numba_stats/_util.py
@@ -13,6 +13,21 @@ def _readonly_carray(T):
 
 
 def _jit(arg, cache=True):
+    """
+    Wrapper for numba.njit to reduce boilerplate code.
+
+    We want to build jitted functions with explicit signatures to restrict
+    the argument types which are used in the implemnetation to float32 or
+    float64. We also want to pass specific options consistently
+    (e.g. error_model='numpy').
+
+    Parameters
+    ----------
+    arg : int
+        Number of arguments. If negative, all arguments of this function are scalars
+        and -arg is the number of arguments. If positive, the first argument is
+        an array, the others are scalars and arg is the number of scalar arguments.
+    """
     if isinstance(arg, list):
         return nb.njit(arg, cache=cache, inline="always", error_model="numpy")
 

--- a/src/numba_stats/norm.py
+++ b/src/numba_stats/norm.py
@@ -6,7 +6,7 @@ See Also
 scipy.stats.norm: Scipy equivalent.
 """
 import numpy as np
-from ._special import erfinv as _erfinv
+from ._special import ndtri as _ndtri
 from ._util import _jit, _trans, _generate_wrappers, _prange
 from math import erf as _erf
 
@@ -33,10 +33,10 @@ def _cdf1(z):
     return T(0.5) * (T(1.0) + _erf(z * c))
 
 
-@_jit(-1, cache=False)  # cannot cache because of _erfinv
+@_jit(-1, cache=False)  # cannot cache because of _ndtri
 def _ppf1(p):
     T = type(p)
-    return T(np.sqrt(2)) * _erfinv(T(2) * p - T(1))
+    return T(_ndtri(p))
 
 
 @_jit(2)


### PR DESCRIPTION
Fixes numba-stats for scipy-1.10, which introduced an internal change which corrupted our internals that were making incorrect assumptions about the stability of certain internal scipy APIs. The fault is not with scipy, they are free to change their internal APIs. The fix does not use implementation details anymore, so this problem should not appear again.