### PR TITLE
Try using vectorize for allowing broadcasting over parameters

### DIFF
--- a/tests/test_poisson.py
+++ b/tests/test_poisson.py
@@ -18,3 +18,13 @@ def test_cdf(mu):
     got = poisson.cdf(k, mu)
     expected = sc.poisson.cdf(k, mu)
     np.testing.assert_allclose(got, expected)
+
+
+@pytest.mark.parametrize("func", ("cdf", "pmf", "logpmf"))
+def test_broadcasting(func):
+    k = np.arange(10)
+    mu = np.array([4, 10, 15])
+
+    got = getattr(poisson, func)(k, mu[:, np.newaxis])
+    expected = getattr(sc.poisson, func)(k, mu[:, np.newaxis])
+    np.testing.assert_allclose(got, expected)


### PR DESCRIPTION
This is a first try at implementing #78 by using `numba.vectorize` instead of `numba.njit`.

However, for now, to just try it out I side-stepped the `_utils` mechanisms.

This seems to work fine and also simplifies the code, since only a single element has to be computed in the function, removing the loop over the shape of `k`.

If you think this approach is good, let's discuss how to adapt the utils mechanism and how to proceed for the other distributions.

