### PR TITLE
Add rvs to several distributions

### DIFF
--- a/bench/test_stats.py
+++ b/bench/test_stats.py
@@ -148,13 +148,14 @@ def test_speed_bernstein_density(benchmark, lib, n):
             return BPoly(np.array(beta)[:, np.newaxis], [xmin, xmax])(x)
 
     else:
-        method = bernstein.density
-
         if lib == "ours:parallel,fastmath":
 
             @nb.njit(parallel=True, fastmath=True)
             def method(x, beta, xmin, xmax):
                 return bernstein.density(x, beta, xmin, xmax)
+
+        else:
+            method = bernstein.density
 
     # warm-up JIT
     method(x, beta, xmin, xmax)

--- a/bench/test_stats.py
+++ b/bench/test_stats.py
@@ -148,13 +148,10 @@ def test_speed_bernstein_density(benchmark, lib, n):
             return BPoly(np.array(beta)[:, np.newaxis], [xmin, xmax])(x)
 
     elif lib == "ours:parallel,fastmath":
-
-        @nb.njit(parallel=True, fastmath=True)
-        def method(x, beta, xmin, xmax):
-            return bernstein.density(x, beta, xmin, xmax)
-
-    else:
         method = bernstein.density
+
+        if lib == "ours:parallel,fastmath":
+            method = nb.njit(parallel=True, fastmath=True)(method)
 
     # warm-up JIT
     method(x, beta, xmin, xmax)

--- a/bench/test_stats.py
+++ b/bench/test_stats.py
@@ -147,15 +147,14 @@ def test_speed_bernstein_density(benchmark, lib, n):
         def method(x, beta, xmin, xmax):
             return BPoly(np.array(beta)[:, np.newaxis], [xmin, xmax])(x)
 
+    elif lib == "ours:parallel,fastmath":
+
+        @nb.njit(parallel=True, fastmath=True)
+        def method(x, beta, xmin, xmax):
+            return bernstein.density(x, beta, xmin, xmax)
+
     else:
-        if lib == "ours:parallel,fastmath":
-
-            @nb.njit(parallel=True, fastmath=True)
-            def method(x, beta, xmin, xmax):
-                return bernstein.density(x, beta, xmin, xmax)
-
-        else:
-            method = bernstein.density
+        method = bernstein.density
 
     # warm-up JIT
     method(x, beta, xmin, xmax)

--- a/src/numba_stats/cpoisson.py
+++ b/src/numba_stats/cpoisson.py
@@ -21,8 +21,6 @@ from ._util import _jit, _generate_wrappers, _prange
 import numpy as np
 
 _doc_par = """
-x: ArrayLike
-    Random variate.
 mu : float
     Expected value.
 """

--- a/src/numba_stats/cruijff.py
+++ b/src/numba_stats/cruijff.py
@@ -8,8 +8,6 @@ from ._util import _jit, _generate_wrappers, _prange
 import numpy as np
 
 _doc_par = """
-x : ArrayLike
-    Random variate.
 beta_left: float
     Left tail acceleration parameter.
 beta_right: float

--- a/src/numba_stats/crystalball_ex.py
+++ b/src/numba_stats/crystalball_ex.py
@@ -12,8 +12,6 @@ from ._util import _jit, _generate_wrappers, _prange
 import numpy as np
 
 _doc_par = """
-x : Array-like
-    Random variate.
 beta_left : float
     Distance from the mode in units of standard deviations where the Crystal Ball
     turns from a gaussian into a power law on the left side.

--- a/src/numba_stats/expon.py
+++ b/src/numba_stats/expon.py
@@ -10,8 +10,6 @@ from math import expm1 as _expm1, log1p as _log1p
 from ._util import _jit, _trans, _generate_wrappers, _prange
 
 _doc_par = """
-x: ArrayLike
-    Random variate.
 loc : float
     Location of the mode.
 scale : float

--- a/src/numba_stats/expon.py
+++ b/src/numba_stats/expon.py
@@ -7,7 +7,7 @@ scipy.stats.expon: Scipy equivalent.
 """
 import numpy as np
 from math import expm1 as _expm1, log1p as _log1p
-from ._util import _jit, _trans, _generate_wrappers, _prange
+from ._util import _jit, _trans, _generate_wrappers, _prange, _rvs_jit, _seed
 
 _doc_par = """
 loc : float
@@ -86,6 +86,13 @@ def _ppf(p, loc, scale):
     for i in _prange(len(z)):
         z[i] = _ppf1(p[i])
     return scale * z + loc
+
+
+@_rvs_jit(2)
+def _rvs(loc, scale, size, random_state):
+    _seed(random_state)
+    p = np.random.uniform(0, 1, size)
+    return _ppf(p, loc, scale)
 
 
 _generate_wrappers(globals())

--- a/src/numba_stats/lognorm.py
+++ b/src/numba_stats/lognorm.py
@@ -10,8 +10,6 @@ from . import norm as _norm
 from ._util import _jit, _trans, _generate_wrappers, _prange
 
 _doc_par = """
-x : ArrayLike
-    Random variate.
 s : float
     Standard deviation of the corresponding normal distribution of exp(x).
 loc : float

--- a/src/numba_stats/lognorm.py
+++ b/src/numba_stats/lognorm.py
@@ -7,7 +7,7 @@ scipy.stats.lognorm: Scipy equivalent.
 """
 import numpy as np
 from . import norm as _norm
-from ._util import _jit, _trans, _generate_wrappers, _prange
+from ._util import _jit, _trans, _generate_wrappers, _prange, _seed, _rvs_jit
 
 _doc_par = """
 s : float
@@ -55,6 +55,13 @@ def _ppf(p, s, loc, scale):
     for i in _prange(len(p)):
         r[i] = np.exp(s * _norm._ppf1(p[i]))
     return scale * r + loc
+
+
+@_rvs_jit(3, cache=False)
+def _rvs(s, loc, scale, size, random_state):
+    _seed(random_state)
+    p = np.random.uniform(0, 1, size)
+    return _ppf(p, s, loc, scale)
 
 
 _generate_wrappers(globals())

--- a/src/numba_stats/norm.py
+++ b/src/numba_stats/norm.py
@@ -7,7 +7,7 @@ scipy.stats.norm: Scipy equivalent.
 """
 import numpy as np
 from ._special import ndtri as _ndtri
-from ._util import _jit, _trans, _generate_wrappers, _prange
+from ._util import _jit, _trans, _generate_wrappers, _prange, _seed, _rvs_jit
 from math import erf as _erf
 
 _doc_par = """
@@ -64,6 +64,13 @@ def _ppf(p, loc, scale):
     for i in _prange(len(r)):
         r[i] = scale * _ppf1(p[i]) + loc
     return r
+
+
+@_rvs_jit(2)
+def _rvs(loc, scale, size, random_state):
+    _seed(random_state)
+    p = np.random.uniform(0, 1, size)
+    return _ppf(p, loc, scale)
 
 
 _generate_wrappers(globals())

--- a/src/numba_stats/norm.py
+++ b/src/numba_stats/norm.py
@@ -66,7 +66,7 @@ def _ppf(p, loc, scale):
     return r
 
 
-@_rvs_jit(2)
+@_rvs_jit(2, cache=False)
 def _rvs(loc, scale, size, random_state):
     _seed(random_state)
     p = np.random.uniform(0, 1, size)

--- a/src/numba_stats/norm.py
+++ b/src/numba_stats/norm.py
@@ -11,8 +11,6 @@ from ._util import _jit, _trans, _generate_wrappers, _prange
 from math import erf as _erf
 
 _doc_par = """
-x : ArrayLike
-    Random variate.
 loc : float
     Location of the mode of the distribution.
 scale : float

--- a/src/numba_stats/poisson.py
+++ b/src/numba_stats/poisson.py
@@ -12,8 +12,6 @@ from math import lgamma as _lgamma
 from ._util import _jit, _generate_wrappers, _prange
 
 _doc_par = """
-x : ArrayLike
-    Random variate.
 mu : float
     Expected value.
 """

--- a/src/numba_stats/qgaussian.py
+++ b/src/numba_stats/qgaussian.py
@@ -16,8 +16,6 @@ from . import norm as _norm, t as _t
 from ._util import _jit, _generate_wrappers
 
 _doc_par = """
-x : ArrayLike
-    Random variate.
 q : float
     Shape parameter between 1 and 3. For q = 1, the qgaussian is a normal distribution,
     for q == 3 it is a cauchy distribution.

--- a/src/numba_stats/qgaussian.py
+++ b/src/numba_stats/qgaussian.py
@@ -85,7 +85,7 @@ def _ppf(p, q, mu, sigma):
     return _t._ppf(p, df, mu, sigma)
 
 
-@_rvs_jit(3)
+@_rvs_jit(3, cache=False)
 def _rvs(q, mu, sigma, size, random_state):
     if q < 1 or q > 3:
         raise ValueError("q < 1 or q > 3 are not supported")

--- a/src/numba_stats/qgaussian.py
+++ b/src/numba_stats/qgaussian.py
@@ -13,7 +13,7 @@ https://en.wikipedia.org/wiki/Q-Gaussian_distribution
 import numpy as np
 import numba as nb
 from . import norm as _norm, t as _t
-from ._util import _jit, _generate_wrappers
+from ._util import _jit, _generate_wrappers, _rvs_jit
 
 _doc_par = """
 q : float
@@ -83,6 +83,19 @@ def _ppf(p, q, mu, sigma):
     df, sigma = _df_sigma(q, sigma)
 
     return _t._ppf(p, df, mu, sigma)
+
+
+@_rvs_jit(3)
+def _rvs(q, mu, sigma, size, random_state):
+    if q < 1 or q > 3:
+        raise ValueError("q < 1 or q > 3 are not supported")
+
+    if q == 1:
+        return _norm._rvs(mu, sigma, size, random_state)
+
+    df, sigma = _df_sigma(q, sigma)
+
+    return _t._rvs(df, mu, sigma, size, random_state)
 
 
 _generate_wrappers(globals())

--- a/src/numba_stats/t.py
+++ b/src/numba_stats/t.py
@@ -7,7 +7,7 @@ scipy.stats.t: Scipy equivalent.
 """
 import numpy as np
 from ._special import stdtr as _stdtr, stdtrit as _stdtrit
-from ._util import _jit, _trans, _generate_wrappers, _prange
+from ._util import _jit, _trans, _generate_wrappers, _prange, _seed, _rvs_jit
 from math import lgamma as _lgamma
 
 _doc_par = """
@@ -58,6 +58,13 @@ def _ppf(p, df, loc, scale):
         else:
             r[i] = _stdtrit(df, p[i])
     return scale * r + loc
+
+
+@_rvs_jit(3)
+def _rvs(df, loc, scale, size, random_state):
+    _seed(random_state)
+    p = np.random.uniform(0, 1, size)
+    return _ppf(p, df, loc, scale)
 
 
 _generate_wrappers(globals())

--- a/src/numba_stats/t.py
+++ b/src/numba_stats/t.py
@@ -11,8 +11,6 @@ from ._util import _jit, _trans, _generate_wrappers, _prange
 from math import lgamma as _lgamma
 
 _doc_par = """
-x: ArrayLike
-    Random variate.
 df : float
     Degrees of freedom.
 loc : float

--- a/src/numba_stats/t.py
+++ b/src/numba_stats/t.py
@@ -60,7 +60,7 @@ def _ppf(p, df, loc, scale):
     return scale * r + loc
 
 
-@_rvs_jit(3)
+@_rvs_jit(3, cache=False)
 def _rvs(df, loc, scale, size, random_state):
     _seed(random_state)
     p = np.random.uniform(0, 1, size)

--- a/src/numba_stats/truncexpon.py
+++ b/src/numba_stats/truncexpon.py
@@ -6,7 +6,7 @@ See Also
 scipy.stats.truncexpon: Scipy equivalent.
 """
 import numpy as np
-from ._util import _jit, _trans, _generate_wrappers, _prange, _rvs_jit
+from ._util import _jit, _trans, _generate_wrappers, _prange, _rvs_jit, _seed
 from . import expon as _expon
 
 _doc_par = """
@@ -76,14 +76,9 @@ def _ppf(p, xmin, xmax, loc, scale):
 
 
 @_rvs_jit(4)
-def _rvs(xmin, xmax, loc, scale, size=1, random_state=None):
-    if random_state is None:
-        np.random.seed()
-    elif isinstance(random_state, int):
-        np.random.seed(random_state)
-    else:
-        raise ValueError("random_state keyword only supports integers")
-    p = np.random.uniform(size)
+def _rvs(xmin, xmax, loc, scale, size, random_state):
+    _seed(random_state)
+    p = np.random.uniform(0, 1, size)
     return _ppf(p, xmin, xmax, loc, scale)
 
 

--- a/src/numba_stats/truncexpon.py
+++ b/src/numba_stats/truncexpon.py
@@ -6,12 +6,10 @@ See Also
 scipy.stats.truncexpon: Scipy equivalent.
 """
 import numpy as np
-from ._util import _jit, _trans, _generate_wrappers, _prange
+from ._util import _jit, _trans, _generate_wrappers, _prange, _rvs_jit
 from . import expon as _expon
 
 _doc_par = """
-x: ArrayLike
-    Random variate.
 xmin : float
     Lower edge of the distribution.
 xmax : float
@@ -75,6 +73,18 @@ def _ppf(p, xmin, xmax, loc, scale):
     for i in _prange(len(z)):
         z[i] = _expon._ppf1(z[i])
     return z * scale + loc
+
+
+@_rvs_jit(4)
+def _rvs(xmin, xmax, loc, scale, size=1, random_state=None):
+    if random_state is None:
+        np.random.seed()
+    elif isinstance(random_state, int):
+        np.random.seed(random_state)
+    else:
+        raise ValueError("random_state keyword only supports integers")
+    p = np.random.uniform(size)
+    return _ppf(p, xmin, xmax, loc, scale)
 
 
 _generate_wrappers(globals())

--- a/src/numba_stats/truncnorm.py
+++ b/src/numba_stats/truncnorm.py
@@ -11,8 +11,6 @@ from . import norm as _norm
 from ._util import _jit, _generate_wrappers, _prange
 
 _doc_par = """
-x: ArrayLike
-    Random variate.
 xmin : float
     Lower edge of the distribution.
 xmin : float

--- a/src/numba_stats/truncnorm.py
+++ b/src/numba_stats/truncnorm.py
@@ -8,7 +8,7 @@ scipy.stats.truncnorm: Scipy equivalent.
 
 import numpy as np
 from . import norm as _norm
-from ._util import _jit, _generate_wrappers, _prange
+from ._util import _jit, _generate_wrappers, _prange, _seed, _rvs_jit
 
 _doc_par = """
 xmin : float
@@ -73,6 +73,13 @@ def _ppf(p, xmin, xmax, loc, scale):
     for i in _prange(len(r)):
         r[i] = _norm._ppf1(r[i])
     return scale * r + loc
+
+
+@_rvs_jit(4, cache=False)
+def _rvs(xmin, xmax, loc, scale, size, random_state):
+    _seed(random_state)
+    p = np.random.uniform(0, 1, size)
+    return _ppf(p, xmin, xmax, loc, scale)
 
 
 _generate_wrappers(globals())

--- a/src/numba_stats/tsallis.py
+++ b/src/numba_stats/tsallis.py
@@ -10,8 +10,6 @@ import numpy as np
 from ._util import _jit, _generate_wrappers
 
 _doc_par = """
-x : ArrayLike
-    Random variate.
 m : float
     Mass of the particle.
 t :  float

--- a/src/numba_stats/uniform.py
+++ b/src/numba_stats/uniform.py
@@ -5,7 +5,7 @@ See Also
 --------
 scipy.stats.uniform: Equivalent in Scipy.
 """
-from ._util import _jit, _generate_wrappers, _prange
+from ._util import _jit, _generate_wrappers, _prange, _rvs_jit, _seed
 import numpy as np
 
 _doc_par = """
@@ -49,6 +49,13 @@ def _cdf(x, a, w):
 @_jit(2)
 def _ppf(p, a, w):
     return w * p + a
+
+
+@_rvs_jit(2)
+def _rvs(a, w, size, random_state):
+    _seed(random_state)
+    p = np.random.uniform(0, 1, size)
+    return _ppf(p, a, w)
 
 
 _generate_wrappers(globals())

--- a/src/numba_stats/uniform.py
+++ b/src/numba_stats/uniform.py
@@ -9,8 +9,6 @@ from ._util import _jit, _generate_wrappers, _prange
 import numpy as np
 
 _doc_par = """
-x : ArrayLike
-    Random variate.
 a : float
     Lower edge of the distribution.
 w : float

--- a/src/numba_stats/voigt.py
+++ b/src/numba_stats/voigt.py
@@ -17,8 +17,6 @@ from ._util import _jit, _generate_wrappers, _prange
 import numpy as np
 
 _doc_par = """
-x : ArrayLike
-    Random variate.
 gamma : float
     The half-width at half-maximum of the Cauchy distribution part.
 loc : float

--- a/tests/test_expon.py
+++ b/tests/test_expon.py
@@ -22,3 +22,10 @@ def test_ppf():
     got = expon.ppf(p, 1, 2)
     expected = sc.expon.ppf(p, 1, 2)
     np.testing.assert_allclose(got, expected)
+
+
+def test_rvs():
+    args = 1, 2
+    x = expon.rvs(*args, size=100_000, random_state=1)
+    r = sc.kstest(x, lambda x: expon.cdf(x, *args))
+    assert r.pvalue > 0.01

--- a/tests/test_lognorm.py
+++ b/tests/test_lognorm.py
@@ -33,6 +33,13 @@ def test_ppf():
     assert_allclose(got, expected)
 
 
+def test_rvs():
+    args = 1.5, 0.1, 1.2
+    x = lognorm.rvs(*args, size=100_000, random_state=1)
+    r = sc.kstest(x, lambda x: lognorm.cdf(x, *args))
+    assert r.pvalue > 0.01
+
+
 def test_njit():
     @nb.njit
     def test(x):

--- a/tests/test_norm.py
+++ b/tests/test_norm.py
@@ -45,6 +45,14 @@ def test_ppf():
     assert_allclose(got, expected)
 
 
+def test_rvs():
+    mu = 2
+    sigma = 3
+    x = norm.rvs(mu, sigma, size=100_000, random_state=1)
+    r = sc.kstest(x, lambda x: norm.cdf(x, mu, sigma))
+    assert r.pvalue > 0.01
+
+
 @pytest.mark.filterwarnings("error")
 @pytest.mark.parametrize("fn", [norm.logpdf, norm.pdf, norm.cdf, norm.ppf])
 @pytest.mark.parametrize("parallel", [False, True])

--- a/tests/test_qgaussian.py
+++ b/tests/test_qgaussian.py
@@ -2,6 +2,7 @@ from numba_stats import qgaussian, t, norm
 import numpy as np
 import pytest
 from scipy.integrate import quad
+from scipy import stats as sc
 
 
 def q_sigma(nu, sigma):
@@ -73,3 +74,11 @@ def test_ppf(q):
     got = f(x)
 
     np.testing.assert_allclose(got, expected)
+
+
+@pytest.mark.parametrize("q", (1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.9, 2.0, 2.5, 2.9))
+def test_rvs(q):
+    args = q, 2, 3
+    x = qgaussian.rvs(*args, size=100_000, random_state=1)
+    r = sc.kstest(x, lambda x: qgaussian.cdf(x, *args))
+    assert r.pvalue > 0.01

--- a/tests/test_t.py
+++ b/tests/test_t.py
@@ -26,3 +26,11 @@ def test_ppf(df):
     got = t.ppf(x, df, 2, 3)
     expected = sc.t.ppf(x, df, 2, 3)  # supports real-valued df
     np.testing.assert_allclose(got, expected)
+
+
+@pytest.mark.parametrize("df", (1, 1.5, 3, 5.5, 10))
+def test_rvs(df):
+    args = df, 2, 3
+    x = t.rvs(*args, size=100_000, random_state=1)
+    r = sc.kstest(x, lambda x: t.cdf(x, *args))
+    assert r.pvalue > 0.01

--- a/tests/test_truncexpon.py
+++ b/tests/test_truncexpon.py
@@ -1,5 +1,6 @@
 import numpy as np
 from numba_stats import truncexpon, expon
+from scipy.stats import kstest
 
 
 def test_pdf():
@@ -49,9 +50,5 @@ def test_rvs():
     mu = 2
     sigma = 3
     x = truncexpon.rvs(xmin, xmax, mu, sigma, size=100_000, random_state=1)
-    p = truncexpon.cdf(x, xmin, xmax, mu, sigma)
-    from matplotlib import pyplot as plt
-
-    plt.hist(p)
-    plt.show()
-    # np.testing.assert_allclose(got, expected, atol=1e-14)
+    r = kstest(x, lambda x: truncexpon.cdf(x, xmin, xmax, mu, sigma))
+    assert r.pvalue > 0.01

--- a/tests/test_truncexpon.py
+++ b/tests/test_truncexpon.py
@@ -41,3 +41,17 @@ def test_ppf():
     x = truncexpon.ppf(expected, xmin, xmax, mu, sigma)
     got = truncexpon.cdf(x, xmin, xmax, mu, sigma)
     np.testing.assert_allclose(got, expected, atol=1e-14)
+
+
+def test_rvs():
+    xmin = 1
+    xmax = 4
+    mu = 2
+    sigma = 3
+    x = truncexpon.rvs(xmin, xmax, mu, sigma, size=100_000, random_state=1)
+    p = truncexpon.cdf(x, xmin, xmax, mu, sigma)
+    from matplotlib import pyplot as plt
+
+    plt.hist(p)
+    plt.show()
+    # np.testing.assert_allclose(got, expected, atol=1e-14)

--- a/tests/test_truncnorm.py
+++ b/tests/test_truncnorm.py
@@ -64,3 +64,13 @@ def test_ppf():
     x = truncnorm.ppf(expected, mu, sigma, xmin, xmax)
     got = truncnorm.cdf(x, mu, sigma, xmin, xmax)
     np.testing.assert_allclose(got, expected, atol=1e-14)
+
+
+def test_rvs():
+    xmin = 1
+    xmax = 4
+    mu = 2
+    sigma = 3
+    x = truncnorm.rvs(xmin, xmax, mu, sigma, size=100_000, random_state=1)
+    r = sc.kstest(x, lambda x: truncnorm.cdf(x, xmin, xmax, mu, sigma))
+    assert r.pvalue > 0.01

--- a/tests/test_uniform.py
+++ b/tests/test_uniform.py
@@ -35,3 +35,10 @@ def test_ppf():
     got = uniform.ppf(0.5, -1, 3)
     expected = sc.uniform.ppf(0.5, -1, 3)
     assert_allclose(got, expected)
+
+
+def test_rvs():
+    args = -1, 2
+    x = uniform.rvs(*args, size=100_000, random_state=1)
+    r = sc.kstest(x, lambda x: uniform.cdf(x, *args))
+    assert r.pvalue > 0.01


### PR DESCRIPTION
Add rvs to compute random variates distributed like the corresponding distribution for
- norm
- lognorm
- expon
- uniform
- t
- qgaussian
- truncexpon
- truncnorm

There are some limitations imposed numba compared to the scipy implementations:
- Arguments size and random_state cannot be omitted
- random_state can only be None or int, it is not possible to pass an instance of a numpy.random.Generator
- Generated variates are always of type float64