### PR TITLE
Fix expon and trunc_expon

### DIFF
--- a/src/numba_stats/expon.py
+++ b/src/numba_stats/expon.py
@@ -19,7 +19,8 @@ scale : float
 
 @_jit(-1)
 def _cdf1(z):
-    return -_expm1(-z)
+    T = type(z)
+    return T(0) if z < 0 else -_expm1(-z)
 
 
 @_jit(-1)
@@ -30,7 +31,10 @@ def _ppf1(p):
 @_jit(2)
 def _logpdf(x, loc, scale):
     z = _trans(x, loc, scale)
-    return -z - np.log(scale)
+    r = np.empty_like(z)
+    for i in _prange(len(r)):
+        r[i] = -np.inf if z[i] < 0 else -z[i] - np.log(scale)
+    return r
 
 
 @_jit(2)

--- a/src/numba_stats/truncexpon.py
+++ b/src/numba_stats/truncexpon.py
@@ -29,6 +29,7 @@ def _logpdf(x, xmin, xmax, loc, scale):
     zmin = (xmin - loc) * scale2
     zmax = (xmax - loc) * scale2
     c = np.log(scale * (_expon._cdf1(zmax) - _expon._cdf1(zmin)))
+    # zmin = max(zmin, T(0))
     for i in _prange(len(z)):
         if zmin <= z[i] < zmax:
             z[i] = -z[i] - c

--- a/src/numba_stats/truncexpon.py
+++ b/src/numba_stats/truncexpon.py
@@ -29,7 +29,7 @@ def _logpdf(x, xmin, xmax, loc, scale):
     zmin = (xmin - loc) * scale2
     zmax = (xmax - loc) * scale2
     c = np.log(scale * (_expon._cdf1(zmax) - _expon._cdf1(zmin)))
-    # zmin = max(zmin, T(0))
+    zmin = max(zmin, T(0))
     for i in _prange(len(z)):
         if zmin <= z[i] < zmax:
             z[i] = -z[i] - c
@@ -53,6 +53,7 @@ def _cdf(x, xmin, xmax, loc, scale):
     pmin = _expon._cdf1(zmin)
     pmax = _expon._cdf1(zmax)
     scale3 = T(1) / (pmax - pmin)
+    zmin = max(zmin, T(0))
     for i in _prange(len(z)):
         if zmin <= z[i]:
             if z[i] < zmax:

--- a/tests/test_expon.py
+++ b/tests/test_expon.py
@@ -4,14 +4,14 @@ from numba_stats import expon
 
 
 def test_pdf():
-    x = np.linspace(1, 5, 20)
+    x = np.linspace(-5, 5, 20)
     got = expon.pdf(x, 1, 2)
     expected = sc.expon.pdf(x, 1, 2)
     np.testing.assert_allclose(got, expected)
 
 
 def test_cdf():
-    x = np.linspace(1, 5, 20) + 3
+    x = np.linspace(-5, 5, 20) + 3
     got = expon.cdf(x, 3, 2)
     expected = sc.expon.cdf(x, 3, 2)
     np.testing.assert_allclose(got, expected)

--- a/tests/test_truncexpon.py
+++ b/tests/test_truncexpon.py
@@ -4,7 +4,7 @@ from scipy.stats import kstest
 
 
 def test_pdf():
-    x = np.linspace(-5, 5, 10)
+    x = np.linspace(-5, 5, 100)
     xmin = 1
     xmax = 4
     mu = 2
@@ -19,7 +19,7 @@ def test_pdf():
 
 
 def test_cdf():
-    x = np.linspace(-5, 5, 10)
+    x = np.linspace(-5, 5, 100)
     xmin = 1
     xmax = 4
     mu = 1.5
@@ -34,7 +34,7 @@ def test_cdf():
 
 
 def test_ppf():
-    expected = np.linspace(0, 1, 10)
+    expected = np.linspace(0, 1, 100)
     xmin = 1
     xmax = 4
     mu = 2

--- a/tests/test_truncexpon.py
+++ b/tests/test_truncexpon.py
@@ -4,7 +4,7 @@ from scipy.stats import kstest
 
 
 def test_pdf():
-    x = np.linspace(-1, 5, 10)
+    x = np.linspace(-5, 5, 10)
     xmin = 1
     xmax = 4
     mu = 2
@@ -19,7 +19,7 @@ def test_pdf():
 
 
 def test_cdf():
-    x = np.linspace(-1, 5, 10)
+    x = np.linspace(-5, 5, 10)
     xmin = 1
     xmax = 4
     mu = 1.5


### PR DESCRIPTION
Closes #83

expon.pdf was not returning 0 below loc. After this was fixed, a related bug in truncexpon was found and fixed.

Both distributions worked correctly if you used them only for x > loc, as is usually the case.