### PR TITLE
Adjust to new scipy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,19 +1,11 @@
 [build-system]
-requires = [
-    "setuptools>=42",
-    "setuptools_scm[toml]>=3.4",
-]
+requires = ["setuptools>=42", "setuptools_scm[toml]>=3.4"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 write_to = "src/numba_stats/_version.py"
 
-[tool.ruff]
-max-length = 90
-
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "-q -ra --ff"
-testpaths = [
-    "tests"
-]
+testpaths = ["tests"]

--- a/src/numba_stats/_special.py
+++ b/src/numba_stats/_special.py
@@ -7,8 +7,15 @@ from numba.types import WrapperAddressProtocol, float64
 
 
 def get(name, signature):
-    # create new function object with correct signature that numba can call by extracting
-    addr = get_cython_function_address("scipy.special.cython_special", name)
+    # create new function object with correct signature that numba can call
+    from scipy.special import cython_special
+
+    # scipy-1.12 started to provide fused versions for some special functions
+    fuse_name = f"__pyx_fuse_1{name}"
+    if fuse_name not in cython_special.__pyx_capi__:
+        fuse_name = name
+
+    addr = get_cython_function_address("scipy.special.cython_special", fuse_name)
 
     # dynamically create type that inherits from WrapperAddressProtocol
     cls = type(


### PR DESCRIPTION
Scipy-1.12 added fused versions for special functions, which we need to call with the correct fuse names. The patch tries the fused name first and falls back to the old name for unfused versions.