### PR TITLE
truncnorm _doc_par typo

### DIFF
--- a/src/numba_stats/truncnorm.py
+++ b/src/numba_stats/truncnorm.py
@@ -13,7 +13,7 @@ from ._util import _jit, _generate_wrappers, _prange, _seed, _rvs_jit
 _doc_par = """
 xmin : float
     Lower edge of the distribution.
-xmin : float
+xmax : float
     Upper edge of the distribution.
 loc : float
     Location of the mode.


### PR DESCRIPTION
Fixed typo mislabelling xmax as xmin.

Thanks for the awesome library (I'm also a heavy user of iminuit).