### PR TITLE
Calculate _powerlaw_integral function in the log space

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,4 +29,4 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - run: python -m pip install --upgrade pip nox
-    - run: nox -s test
+    - run: nox -s mintest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,4 +29,4 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - run: python -m pip install --upgrade pip nox
-    - run: nox -s mintest
+    - run: nox -s test

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,6 +26,14 @@ nox.options.sessions = ["mintest", "maxtest"]
 # running in parallel with pytest-xdist does not make the tests faster
 
 
+# doesn't work on my windows machine but needed for CI
+@nox.session(reuse_venv=True)
+def test(session: nox.Session) -> None:
+    """Run all tests."""
+    session.install("-e.[test]")
+    session.run("pytest", *session.posargs)
+
+
 @nox.session(python=MINIMUM_PYTHON, reuse_venv=True)
 def mintest(session: nox.Session) -> None:
     """Run all tests."""

--- a/noxfile.py
+++ b/noxfile.py
@@ -21,13 +21,13 @@ PYPROJECT = nox.project.load_toml("pyproject.toml")
 MINIMUM_PYTHON = PYPROJECT["project"]["requires-python"].strip(">=")
 LATEST_PYTHON = str(python_releases.latest())
 
-nox.options.sessions = ["test", "maxtest"]
+nox.options.sessions = ["mintest", "maxtest"]
 
 # running in parallel with pytest-xdist does not make the tests faster
 
 
-@nox.session(reuse_venv=True)
-def test(session: nox.Session) -> None:
+@nox.session(python=MINIMUM_PYTHON, reuse_venv=True)
+def mintest(session: nox.Session) -> None:
     """Run all tests."""
     session.install("-e.[test]")
     session.run("pytest", *session.posargs)

--- a/src/numba_stats/crystalball.py
+++ b/src/numba_stats/crystalball.py
@@ -38,10 +38,9 @@ def _log_powerlaw(z, beta, m):
 @_jit(3, narg=0)
 def _powerlaw_integral(z, beta, m):
     T = type(beta)
-    c = -T(0.5) * beta**2
-    log_a = m * np.log(m / beta) + c
+    log_a = m * np.log(m / beta) - T(0.5) * beta * beta
     b = m / beta - beta
-    m1 = m - type(m)(1)
+    m1 = m - T(1)
     return np.exp(log_a - m1 * np.log(b - z) - np.log(m1))
 
 

--- a/src/numba_stats/crystalball.py
+++ b/src/numba_stats/crystalball.py
@@ -38,12 +38,11 @@ def _log_powerlaw(z, beta, m):
 @_jit(3, narg=0)
 def _powerlaw_integral(z, beta, m):
     T = type(beta)
-    exp_beta = np.exp(-T(0.5) * beta * beta)
-    a = (m / beta) ** m * exp_beta
+    c = -T(0.5) * beta**2
+    log_a = m * np.log(m / beta) + c
     b = m / beta - beta
     m1 = m - type(m)(1)
-    return a * (b - z) ** -m1 / m1
-
+    return np.exp(log_a - m1 * np.log(b-z) - np.log(m1))
 
 @_jit(2, narg=0)
 def _normal_integral(a, b):

--- a/src/numba_stats/crystalball.py
+++ b/src/numba_stats/crystalball.py
@@ -42,7 +42,8 @@ def _powerlaw_integral(z, beta, m):
     log_a = m * np.log(m / beta) + c
     b = m / beta - beta
     m1 = m - type(m)(1)
-    return np.exp(log_a - m1 * np.log(b-z) - np.log(m1))
+    return np.exp(log_a - m1 * np.log(b - z) - np.log(m1))
+
 
 @_jit(2, narg=0)
 def _normal_integral(a, b):

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -3,6 +3,7 @@ import pkgutil
 import numba_stats
 import subprocess as subp
 import importlib
+import sys
 
 all_modules = []
 for _, modname, ispkg in pkgutil.walk_packages(numba_stats.__path__):
@@ -15,6 +16,6 @@ for _, modname, ispkg in pkgutil.walk_packages(numba_stats.__path__):
 def test_all(module):
     pytest.importorskip("pydocstyle")
     m = importlib.import_module(f"numba_stats.{module}")
-    r = subp.run(["python", "-m", "pydocstyle", m.__file__], stdout=subp.PIPE)
+    r = subp.run([sys.executable, "-m", "pydocstyle", m.__file__], stdout=subp.PIPE)
     rc = int(r.returncode)
     assert rc == 0, r.stdout.decode("utf8")


### PR DESCRIPTION
Closes #121. This change gets rid of an instability in the powerlaw integral function, by calculating it in the log space.