### PR TITLE
ci: drop python 3.9 and test against python 3.13 and 3.14

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 0  # needed by setuptools_scm
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: '3.13'
 
     - run: python -m pip install --upgrade pip build
     - run: python -m build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.10", "3.13", "3.14", "3.14t"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.13", "3.14", "3.14t"]
+        python-version: ["3.10", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,13 @@ repos:
   - id: trailing-whitespace
     exclude: .*\.svg
 
+# Upgrade syntax for newer Python versions
+- repo: https://github.com/asottile/pyupgrade
+  rev: v3.21.2
+  hooks:
+  - id: pyupgrade
+    args: ["--py310-plus"]
+
 # Ruff linter, replacement for flake8, pydocstyle, isort
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: 'v0.12.4'

--- a/noxfile.py
+++ b/noxfile.py
@@ -48,8 +48,7 @@ def maxtest(session: nox.Session) -> None:
     session.run("pytest", *session.posargs, env=ENV)
 
 
-# Python-3.12 provides coverage info faster
-@nox.session(python="3.12", reuse_venv=True)
+@nox.session(python="3.13", reuse_venv=True)
 def cov(session: nox.Session) -> None:
     """Run covage and place in 'htmlcov' directory."""
     import warnings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,11 @@ classifiers = [
     "Programming Language :: Python :: 3",
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3 :: Only',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
     'Programming Language :: Python :: Implementation :: CPython',
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "numba-stats"
 dynamic = ["version"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = ["numba>=0.53", "numpy>=1.20", "scipy>=1.5"]
 authors = [{ name = "Hans Dembinski", email = "hans.dembinski@gmail.com" }]
 readme = "README.md"


### PR DESCRIPTION
Drops python 3.9 and tests against python 3.13 and 3.14