### PR TITLE
fix: scipy 1.17 compatibility

### DIFF
--- a/src/numba_stats/_special.py
+++ b/src/numba_stats/_special.py
@@ -13,7 +13,7 @@ def get(name: str, signature: Any) -> Any:
     from scipy.special import cython_special
 
     # scipy-1.12 started to provide fused versions for some special functions
-    if name == "betainc":
+    if name in {"betainc", "stdtr", "stdtrit"}:
         fuse_name = f"__pyx_fuse_0{name}"
     else:
         fuse_name = f"__pyx_fuse_1{name}"


### PR DESCRIPTION
`stdtr` and `stdtrit` have fused versions in scipy 1.17 and the one with the double type signature is the one with `__pyx_fuse_0` in their name.
Before scipy 1.17, those functions did not have fused versions so this change is backwards compatible as before scipy 1.17 they are getting grabbed using this block right below the change.
```
    if fuse_name not in cython_special.__pyx_capi__:
        fuse_name = name
 ```